### PR TITLE
docs: rebuild the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,121 +1,188 @@
-# Astro Browser
+<h1 align="center">Astro</h1>
 
-A de-Googled Chromium browser by [Oxy](https://oxy.so). Astro strips all Google services from Chromium and replaces them with privacy-respecting Oxy platform equivalents.
+<p align="center">
+  A Chromium fork by Oxy with every Google service taken out and replaced, not merely switched off.
+</p>
 
-## Features
+<p align="center">
+  <img alt="Chromium 146" src="https://img.shields.io/badge/Chromium-146.0.7680.177-440151?style=flat-square&logo=googlechrome&logoColor=white">
+  <img alt="168 patches" src="https://img.shields.io/badge/patches-112%20ungoogled%20%2B%2056%20Astro-440151?style=flat-square">
+  <img alt="Platforms" src="https://img.shields.io/badge/Linux%20%C2%B7%20Android%20%C2%B7%20macOS%20%C2%B7%20Windows-440151?style=flat-square">
+  <img alt="Bun" src="https://img.shields.io/badge/bun-webui-440151?style=flat-square&logo=bun&logoColor=white">
+  <img alt="Rust" src="https://img.shields.io/badge/Rust-adblock%20engine-440151?style=flat-square&logo=rust&logoColor=white">
+</p>
 
-- **De-Googled** — 112 ungoogled-chromium patches + 55 Astro patches (167 total)
-- **Oxy Account** — Sign in with Oxy, cookie-based auth like Chrome/Google
-- **Alia AI** — Built-in AI assistant sidebar (like Edge Copilot)
-- **Ad Blocker** — Built-in ad and tracker blocking, no extensions needed
-- **Custom NTP** — Widgets, wallpaper, weather, quick links, notes
-- **`astro://` URLs** — 11 integration points (Brave-style scheme implementation)
-- **Oxy Fuchsia Theme** — #c46ede default frame color, customizable
-- **DuckDuckGo** — Default search engine, 5 engines available
-- **Privacy-First** — Zero Google connections, all domains substituted/blocked
-- **Cross-Platform** — Linux, Android, Windows, macOS (no iOS)
-- **Extension Support** — Full Chrome Web Store compatibility
+<p align="center">
+  <b>This is a source tree, not a download.</b><br>
+  Astro is the patch set, the C++ overlay and the build scripts that turn upstream Chromium<br>
+  into the browser Oxy ships. Building it takes hours and about 120 GB.
+</p>
 
-## System Requirements
+---
+
+<table>
+<tr>
+<td valign="top" width="50%">
+
+### 🚫 Everything Google is gone
+
+112 [ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium) patches remove Google account and sync infrastructure, Safe Browsing pings, Google Update, the hard coded API keys and OAuth secrets, and the prefetches that reach Google domains before you type anything.
+
+56 Astro patches finish the job: branding, the product menu, the settings surface, and the remaining `chrome://` strings.
+
+</td>
+<td valign="top" width="50%">
+
+### 🪐 A real Oxy browser, not a skin
+
+Sign in with Oxy is a browser level service, so the account you use for the web is the account the browser knows. Alia, the AI assistant, lives in the side panel rather than a tab.
+
+The ad blocker is a Rust engine compiled into the browser and wired into the network stack, so there is no extension to install and nothing to disable it.
+
+</td>
+</tr>
+</table>
+
+## What is different from upstream
+
+| Aspect | Astro |
+|---|---|
+| Base | Chromium 146.0.7680.177 |
+| De-Google patches | 112, inherited from ungoogled-chromium |
+| Oxy patches | 56, in `patches/astro/001` through `056` |
+| URL scheme | `astro://`, aliased onto `chrome://` |
+| Internal pages | 5, built as Vite and Tailwind apps rather than Polymer |
+| Default search | DuckDuckGo, with Google, Bing, Brave Search and Startpage also available |
+| Ad blocking | In process Rust engine, no extension |
+| Account | Sign in with Oxy, no Google Sign In |
+| Platforms | Linux, Android, macOS, Windows. No iOS |
+
+All Astro C++ lives in a self contained overlay at `src/chrome/browser/oxy/`, the same way Brave keeps its code separate from upstream. `rsync` drops it onto the Chromium tree before each build, so nothing Astro specific is scattered through Chromium's own directories.
+
+## Internal pages
+
+The five `astro://` pages are standalone Vite and Tailwind v4 apps that talk to the browser process over Mojo IPC, which means type safe calls in both directions and live pref updates pushed to the page.
+
+| Page | Source | What it does |
+|---|---|---|
+| New Tab | [`webui/ntp/`](webui/ntp) | Clock, notes, quick links, weather, wallpaper, an Alia prompt, and a badge counting what the ad blocker stopped |
+| Settings | [`webui/settings/`](webui/settings) | Reads and writes real Chromium prefs through a Mojo `PageHandler` |
+| Alia | [`webui/alia/`](webui/alia) | The AI side panel |
+| What's New | [`webui/whats-new/`](webui/whats-new) | Release notes |
+| Error | [`webui/error/`](webui/error) | Network and navigation error pages |
+
+```bash
+cd webui/ntp && bun install && bun run dev
+```
+
+Each page is its own Bun workspace with its own dev server, so you can iterate on one without rebuilding the browser.
+
+## Building
+
+<details>
+<summary><b>What it costs before you start</b></summary>
+
+<br>
 
 | Resource | Minimum | Recommended |
-|----------|---------|-------------|
-| **Disk** | 120 GB | 200 GB |
-| **RAM** | 16 GB | 32 GB |
-| **CPU** | 8 cores | 16+ cores |
-| **Download** | ~55 GB (Chromium source + deps) | — |
+|---|---|---|
+| Disk | 120 GB | 200 GB |
+| RAM | 16 GB | 32 GB |
+| CPU | 8 cores | 16 or more |
+| Download | about 55 GB | |
 
-## Build Times (approximate)
+Roughly two to four hours from nothing to a running binary, most of it the Chromium fetch and the first compile. Incremental builds are seconds to minutes.
 
-| Step | Time | Notes |
-|------|------|-------|
-| **Chromium fetch** | 30-90 min | ~55 GB download, depends on connection |
-| **gclient sync + hooks** | 15-30 min | Third-party deps + toolchain |
-| **Apply patches** | 2-5 min | 167 patches + domain substitution |
-| **First build** | 1-3 hours | Depends on CPU cores (32 cores ≈ 1 hour) |
-| **Incremental build** | 10 sec - 5 min | Only recompiles changed files |
-| **Total first time** | ~2-4 hours | From scratch to working binary |
+You need a 64 bit Linux machine for Linux, Android and cross compiled Windows builds, or macOS for native macOS builds. Bun 1.0 or newer for the WebUI workspaces, plus the usual Chromium build dependencies. Full prerequisites are in [`docs/build.mdx`](docs/build.mdx).
 
-## Quick Start
+</details>
+
+A clean build is five commands:
 
 ```bash
-# 1. Fetch Chromium source (~55 GB, takes 30-90 min)
-tools/fetch-chromium.sh
-
-# 2. Sync ungoogled-chromium patches
-tools/sync-ungoogled.sh
-
-# 3. Apply all patches (ungoogled + Astro)
-tools/apply-patches.sh
-
-# 4. Copy Astro source overlay
-rsync -av src/ chromium/src/
-
-# 5. Build (uses all available CPU cores)
-tools/build.sh
-
-# 6. Install locally
-tools/install-local.sh
-
-# 7. Run
-astro --no-sandbox
+tools/fetch-chromium.sh        # 1. fetch Chromium source, about 55 GB
+tools/sync-ungoogled.sh        # 2. pull the matching ungoogled-chromium patches
+tools/apply-patches.sh         # 3. prune binaries, substitute domains, apply 168 patches
+rsync -av src/ chromium/src/   # 4. drop the Astro overlay on the tree
+tools/build.sh                 # 5. build with autoninja
 ```
 
-## Development (WebUI Pages)
+Then `tools/install-local.sh` to install it and run `astro`.
 
-The internal pages (NTP, Settings, Alia, What's New) are built with Vite + Tailwind:
+> [!WARNING]
+> Never run `rsync --delete` against the Chromium tree. Third party dependencies fetched by `gclient` live alongside the overlay paths and will be removed.
+
+<details>
+<summary><b>Every script in <code>tools/</code></b></summary>
+
+<br>
 
 ```bash
-# Start dev servers (hot reload)
-cd webui/ntp && bun run dev          # http://localhost:5173
-cd webui/alia && bun run dev         # http://localhost:5174
-cd webui/settings && bun run dev     # http://localhost:5175
-cd webui/whats-new && bun run dev    # http://localhost:5176
+tools/fetch-chromium.sh        # fetch source; CHROMIUM_VERSION=... to override the pin
+tools/sync-ungoogled.sh        # sync patches for the pinned Chromium version
+tools/apply-patches.sh         # pruning, domain substitution, then patches in order
+tools/build.sh                 # tools/build.sh [Release|Debug] [linux|android|macos|windows]
+tools/install-local.sh         # install to the system
+tools/update-chromium.sh VER   # rebase onto a new Chromium version
+tools/apply-branding.sh        # regenerate branding from branding/astro.conf
+tools/vendor-adblock-rust.sh   # vendor the Rust adblock dependencies
+tools/fetch-cross-deps.sh      # sysroots for cross compilation
+tools/astro-launch.sh          # launch a local build
+tools/package-release.sh       # package for distribution
+tools/package-linux.sh         # per platform packaging
+tools/package-deb.sh
+tools/package-android.sh
+tools/package-macos.sh
+tools/package-windows.sh
 ```
 
-## Project Structure
+GN args per platform live in [`gn_args/`](gn_args): `linux.gn`, `linux_debug.gn`, `android.gn`, `macos.gn`, `windows.gn`, `windows_arm64.gn`.
 
-```
-Astro/
-├── patches/
-│   ├── ungoogled/          # 112 de-Google patches
-│   └── astro/              # 55 Astro-specific patches
-├── src/chrome/browser/oxy/ # C++ Oxy integration
-│   ├── oxy_auth_*          # Cookie-based auth + JWT
-│   ├── oxy_alia_*          # Alia AI sidebar panel
-│   ├── oxy_cookie_*        # Cookie observer for auto sign-in
-│   ├── adblock/            # Built-in ad blocker
-│   └── webui/              # WebUI controllers + handlers
-├── webui/
-│   ├── ntp/                # New Tab Page (Vite + Tailwind)
-│   ├── alia/               # Alia AI Panel (Vite + Tailwind)
-│   ├── settings/           # Settings Page (Vite + Tailwind)
-│   └── whats-new/          # What's New Page (Vite + Tailwind)
-├── branding/               # Logos, icons, .desktop file, astro.conf
-├── gn_args/                # Build configs (linux, android, macos, windows)
-└── tools/                  # Build, install, patch scripts
-```
+</details>
 
-## Updating Chromium
+<details>
+<summary><b>Rebasing onto a new Chromium</b></summary>
+
+<br>
 
 ```bash
-# Update to a new Chromium version
 tools/update-chromium.sh 147.0.XXXX.XX
 ```
 
-This fetches the new version, syncs matching ungoogled patches, and attempts to apply all Astro patches. Patch conflicts may need manual resolution.
+That fetches the new version, syncs the matching ungoogled patches, and replays the Astro patches in numbered order. When one fails to apply, the script stops and names the patch and its reject file so you can resolve the conflict by hand rather than discovering it at link time.
 
-## Branding
+</details>
 
-All branding is centralized in `branding/astro.conf`. To rebrand:
+<details>
+<summary><b>Rebranding</b></summary>
+
+<br>
+
+Every user facing name, URL, icon and theme colour is declared once in [`branding/astro.conf`](branding/astro.conf). Edit it and run:
 
 ```bash
-# Edit branding/astro.conf, then:
 tools/apply-branding.sh
 ```
 
+That rewrites the `.grd` resource strings and the `BRANDING` file Chromium's build system reads, and regenerates the icon sizes from the source SVG.
+
+</details>
+
+## Documentation
+
+| Document | Covers |
+|---|---|
+| [`docs/index.mdx`](docs/index.mdx) | What Astro is and how it differs from Chromium |
+| [`docs/build.mdx`](docs/build.mdx) | Prerequisites, the build workflow, cross compiling, packaging |
+| [`docs/architecture.mdx`](docs/architecture.mdx) | The overlay, the patch system, Mojo |
+| [`docs/oxy-integration.mdx`](docs/oxy-integration.mdx) | Auth, Alia, and the Oxy services behind them |
+
 ## License
 
-Chromium is licensed under the BSD license. Astro-specific code is proprietary to Oxy.
+Chromium is under the BSD license. Astro specific code is proprietary to Oxy.
 
-Made with ❤️ in the 🌎 by Oxy.
+<br>
+
+<div align="center">
+<sub>built by <a href="https://oxy.so">Oxy</a></sub>
+</div>


### PR DESCRIPTION
## What was wrong

The old README was structurally fine, but the numbers had drifted away from the tree.

| Claim | Reality |
|---|---|
| 55 Astro patches, 167 total | `patches/astro/` holds 56, so 168 total |
| 4 internal pages | 5. `webui/error/` was missing from the dev server list and the project tree |
| "`astro://` URLs, 11 integration points" | Nothing in the repo supports that number, so it is gone |
| 7 scripts in `tools/` | There are 17 |
| 4 files in `gn_args/` | There are 6, including `linux_debug.gn` and `windows_arm64.gn` |
| No Chromium version anywhere | `tools/fetch-chromium.sh` pins `146.0.7680.177` |

That last one is the important one. The pinned Chromium version is the first thing anyone building this repository needs, and the front page did not say it.

## What it says now

- A "what is different from upstream" table with the base version, both patch counts, the URL scheme, the internal page count, the default search engine, and the platform list.
- The five `astro://` pages, each linked to its `webui/` workspace, with the NTP widget list read from `webui/ntp/src/index.html` (clock, notes, quick links, weather, wallpaper, Alia prompt, blocked count) and the five search engines read from the engine dropdown.
- The five command clean build, with the full `tools/` script list folded below it, plus rebasing and rebranding as their own collapsed sections so the page opens short.
- The `rsync --delete` warning from `docs/build.mdx`, promoted to the README because it is the one mistake that costs an afternoon.
- Links to all four documents under `docs/`.

The license note is unchanged in substance: Chromium under BSD, Astro specific code proprietary to Oxy. There is no `LICENSE` file in the repository, so no license badge is claimed.

House style throughout. No em or en dashes. Only `README.md` is touched.

## One thing to check

`docs/index.mdx` describes browser sign in as sitting on a `fedcm_session` cookie. The platform moved to a zero cookie, device first session model, so that paragraph may now be describing something that no longer exists. The new README stays at "Sign in with Oxy is a browser level service" and does not repeat the cookie detail, but `docs/index.mdx` and the C++ in `oxy_cookie_signin_observer.*` are worth a look. Out of scope here since this PR only touches the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)