### PR TITLE
ASTRO-NEXT-002: pin exact source and toolchain revisions, and sync deterministically

### DIFF
--- a/.github/workflows/build-safety.yml
+++ b/.github/workflows/build-safety.yml
@@ -14,7 +14,11 @@ on:
       - 'tools/**'
       - 'patches/**'
       - 'src/**'
-      - '.github/workflows/build-safety.yml'
+      - 'browser.lock.json'
+      - 'browser.lock.schema.json'
+      - 'docs/astro-next/**'
+      - 'gn_args/**'
+      - '.github/workflows/**'
   push:
     branches: [master]
   workflow_dispatch:
@@ -42,20 +46,34 @@ jobs:
           shellcheck --version | grep version:
           git --version
 
+      - name: Validate the source lock
+        run: python3 tools/lib/lock.py --validate
+
+      # The baseline is what later issues cite as their compatibility
+      # reference, so a stale document is worse than a missing one.
+      - name: Check the Astro Next baseline is current
+        run: tools/baseline/generate-all.sh --check
+
       - name: Run the build-safety suite
         run: tools/tests/run.sh
 
-      # ASTRO_ALLOW_DIRTY_CHROMIUM is a developer-only escape hatch. If it ever
-      # appears in CI configuration, the guards it bypasses stop being gates.
+      # These are developer-only escape hatches: one waves through a Chromium
+      # checkout carrying unrelated local changes, the other waves through an
+      # overlay that does not match the commit being built. If either ever
+      # appears in CI configuration, the guard it bypasses stops being a gate.
+      # The prefix match also covers ASTRO_ALLOW_DIRTY_OVERLAY_PACKAGE, which
+      # would let CI publish an artifact no revision reproduces.
       - name: Assert no override is set in CI
         run: |
-          if [ -n "${ASTRO_ALLOW_DIRTY_CHROMIUM:-}" ]; then
-            echo "ASTRO_ALLOW_DIRTY_CHROMIUM is set in CI; it is developer-only." >&2
-            exit 1
-          fi
-          if grep -rn 'ASTRO_ALLOW_DIRTY_CHROMIUM' .github/workflows/ \
-              | grep -v 'build-safety.yml'; then
-            echo "A workflow sets the dirty-checkout override." >&2
-            exit 1
-          fi
+          for override in ASTRO_ALLOW_DIRTY_CHROMIUM ASTRO_ALLOW_DIRTY_OVERLAY; do
+            if [ -n "${!override:-}" ]; then
+              echo "$override is set in CI; it is developer-only." >&2
+              exit 1
+            fi
+            if grep -rn "$override" .github/workflows/ \
+                | grep -v 'build-safety.yml'; then
+              echo "A workflow sets $override." >&2
+              exit 1
+            fi
+          done
           echo "No override set."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,20 @@ on:
 permissions:
   contents: write
 
-env:
-  CHROMIUM_VERSION: "146.0.7680.177"
+# No CHROMIUM_VERSION here on purpose. browser.lock.json is the single
+# declaration of what gets compiled; an env var that could disagree with it is
+# exactly the ambiguity ASTRO-NEXT-002 (#5) removes.
+
+# Every job passes its gclient target_os explicitly to tools/sync-sources.sh.
+# Leaving it implicit meant each job synced with the default (linux) and the
+# Windows, macOS and Android jobs depended on however that runner's checkout
+# had last been configured — the same "the runner decides" defect the source
+# lock exists to remove, one level down in the dependency graph.
+
+# One shared checkout per runner must not be mutated by two jobs at once.
+concurrency:
+  group: astro-sources-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   # ---------------------------------------------------------------------------
@@ -67,24 +79,30 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - name: Fetch Chromium (skip if cached)
-        run: |
-          if [ ! -d "chromium/src/.git" ]; then
-            tools/fetch-chromium.sh
-          else
-            echo "Chromium source cached, skipping fetch"
-          fi
+      # A cache is an object/download cache, never source-of-truth state.
+      # The previous version skipped synchronisation whenever
+      # chromium/src/.git existed, so a runner that had ever fetched
+      # Chromium compiled whatever commit it happened to hold, forever,
+      # with nothing validating it.
+      - name: Sync sources to the locked revisions
+        run: tools/sync-sources.sh --targets "linux"
+
+      # Fails the job if anything on disk disagrees with browser.lock.json.
+      # Separate from the sync above so a sync that silently did nothing
+      # still cannot produce a build.
+      - name: Verify source revisions against the lock
+        run: tools/sync-sources.sh --verify-only --targets "linux"
 
       - name: Sync ungoogled patches
         run: tools/sync-ungoogled.sh
 
-      - name: Reset and apply patches
-        run: |
-          cd chromium/src
-          git checkout -- . 2>/dev/null || true
-          git clean -fd 2>/dev/null || true
-          cd ../..
-          tools/apply-patches.sh all
+      # tools/sync-sources.sh has already put the checkout at the locked
+      # commit and refused it if it carried state nobody can account for.
+      # The previous `git checkout -- . 2>/dev/null || true` plus
+      # `git clean -fd 2>/dev/null || true` discarded whatever it found
+      # and hid its own failures while doing so.
+      - name: Apply patches
+        run: tools/apply-patches.sh all --skip-domain-substitution
 
       - name: Build WebUI
         run: |
@@ -146,27 +164,34 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - name: Fetch Chromium (skip if cached)
+      # A cache is an object/download cache, never source-of-truth state.
+      # The previous version skipped synchronisation whenever
+      # chromium/src/.git existed, so a runner that had ever fetched
+      # Chromium compiled whatever commit it happened to hold, forever,
+      # with nothing validating it.
+      - name: Sync sources to the locked revisions
         shell: bash
-        run: |
-          if [ ! -d "chromium/src/.git" ]; then
-            tools/fetch-chromium.sh
-          else
-            echo "Chromium source cached, skipping fetch"
-          fi
+        run: tools/sync-sources.sh --targets "win"
+
+      # Fails the job if anything on disk disagrees with browser.lock.json.
+      # Separate from the sync above so a sync that silently did nothing
+      # still cannot produce a build.
+      - name: Verify source revisions against the lock
+        shell: bash
+        run: tools/sync-sources.sh --verify-only --targets "win"
 
       - name: Sync ungoogled patches
         shell: bash
         run: tools/sync-ungoogled.sh
 
-      - name: Reset and apply patches
+      # tools/sync-sources.sh has already put the checkout at the locked
+      # commit and refused it if it carried state nobody can account for.
+      # The previous `git checkout -- . 2>/dev/null || true` plus
+      # `git clean -fd 2>/dev/null || true` discarded whatever it found
+      # and hid its own failures while doing so.
+      - name: Apply patches
         shell: bash
-        run: |
-          cd chromium/src
-          git checkout -- . 2>/dev/null || true
-          git clean -fd 2>/dev/null || true
-          cd ../..
-          tools/apply-patches.sh all
+        run: tools/apply-patches.sh all --skip-domain-substitution
 
       - name: Build WebUI
         shell: bash
@@ -235,27 +260,34 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - name: Fetch Chromium (skip if cached)
+      # A cache is an object/download cache, never source-of-truth state.
+      # The previous version skipped synchronisation whenever
+      # chromium/src/.git existed, so a runner that had ever fetched
+      # Chromium compiled whatever commit it happened to hold, forever,
+      # with nothing validating it.
+      - name: Sync sources to the locked revisions
         shell: bash
-        run: |
-          if [ ! -d "chromium/src/.git" ]; then
-            tools/fetch-chromium.sh
-          else
-            echo "Chromium source cached, skipping fetch"
-          fi
+        run: tools/sync-sources.sh --targets "win"
+
+      # Fails the job if anything on disk disagrees with browser.lock.json.
+      # Separate from the sync above so a sync that silently did nothing
+      # still cannot produce a build.
+      - name: Verify source revisions against the lock
+        shell: bash
+        run: tools/sync-sources.sh --verify-only --targets "win"
 
       - name: Sync ungoogled patches
         shell: bash
         run: tools/sync-ungoogled.sh
 
-      - name: Reset and apply patches
+      # tools/sync-sources.sh has already put the checkout at the locked
+      # commit and refused it if it carried state nobody can account for.
+      # The previous `git checkout -- . 2>/dev/null || true` plus
+      # `git clean -fd 2>/dev/null || true` discarded whatever it found
+      # and hid its own failures while doing so.
+      - name: Apply patches
         shell: bash
-        run: |
-          cd chromium/src
-          git checkout -- . 2>/dev/null || true
-          git clean -fd 2>/dev/null || true
-          cd ../..
-          tools/apply-patches.sh all
+        run: tools/apply-patches.sh all --skip-domain-substitution
 
       - name: Build WebUI
         shell: bash
@@ -322,24 +354,30 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - name: Fetch Chromium (skip if cached)
-        run: |
-          if [ ! -d "chromium/src/.git" ]; then
-            tools/fetch-chromium.sh
-          else
-            echo "Chromium source cached, skipping fetch"
-          fi
+      # A cache is an object/download cache, never source-of-truth state.
+      # The previous version skipped synchronisation whenever
+      # chromium/src/.git existed, so a runner that had ever fetched
+      # Chromium compiled whatever commit it happened to hold, forever,
+      # with nothing validating it.
+      - name: Sync sources to the locked revisions
+        run: tools/sync-sources.sh --targets "mac"
+
+      # Fails the job if anything on disk disagrees with browser.lock.json.
+      # Separate from the sync above so a sync that silently did nothing
+      # still cannot produce a build.
+      - name: Verify source revisions against the lock
+        run: tools/sync-sources.sh --verify-only --targets "mac"
 
       - name: Sync ungoogled patches
         run: tools/sync-ungoogled.sh
 
-      - name: Reset and apply patches
-        run: |
-          cd chromium/src
-          git checkout -- . 2>/dev/null || true
-          git clean -fd 2>/dev/null || true
-          cd ../..
-          tools/apply-patches.sh all
+      # tools/sync-sources.sh has already put the checkout at the locked
+      # commit and refused it if it carried state nobody can account for.
+      # The previous `git checkout -- . 2>/dev/null || true` plus
+      # `git clean -fd 2>/dev/null || true` discarded whatever it found
+      # and hid its own failures while doing so.
+      - name: Apply patches
+        run: tools/apply-patches.sh all --skip-domain-substitution
 
       - name: Build WebUI
         run: |
@@ -396,13 +434,19 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      - name: Fetch Chromium (skip if cached)
-        run: |
-          if [ ! -d "chromium/src/.git" ]; then
-            CHROMIUM_VERSION=${{ env.CHROMIUM_VERSION }} tools/fetch-chromium.sh
-          else
-            echo "Chromium source cached, skipping fetch"
-          fi
+      # A cache is an object/download cache, never source-of-truth state.
+      # The previous version skipped synchronisation whenever
+      # chromium/src/.git existed, so a runner that had ever fetched
+      # Chromium compiled whatever commit it happened to hold, forever,
+      # with nothing validating it.
+      - name: Sync sources to the locked revisions
+        run: tools/sync-sources.sh --targets "android"
+
+      # Fails the job if anything on disk disagrees with browser.lock.json.
+      # Separate from the sync above so a sync that silently did nothing
+      # still cannot produce a build.
+      - name: Verify source revisions against the lock
+        run: tools/sync-sources.sh --verify-only --targets "android"
 
       - name: Install Android dependencies
         run: |
@@ -412,13 +456,13 @@ jobs:
       - name: Sync ungoogled patches
         run: tools/sync-ungoogled.sh
 
-      - name: Reset and apply patches
-        run: |
-          cd chromium/src
-          git checkout -- . 2>/dev/null || true
-          git clean -fd 2>/dev/null || true
-          cd ../..
-          tools/apply-patches.sh all
+      # tools/sync-sources.sh has already put the checkout at the locked
+      # commit and refused it if it carried state nobody can account for.
+      # The previous `git checkout -- . 2>/dev/null || true` plus
+      # `git clean -fd 2>/dev/null || true` discarded whatever it found
+      # and hid its own failures while doing so.
+      - name: Apply patches
+        run: tools/apply-patches.sh all --skip-domain-substitution
 
       - name: Build WebUI
         run: |

--- a/browser.lock.json
+++ b/browser.lock.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "./browser.lock.schema.json",
+  "lockfile_version": 1,
+
+  "chromium": {
+    "version": "146.0.7680.177",
+    "commit": "ae03f7fb2cf1215853896d6a4c15fdceee2badb7",
+    "url": "https://chromium.googlesource.com/chromium/src.git",
+    "ref": "refs/tags/146.0.7680.177"
+  },
+
+  "depot_tools": {
+    "commit": "41c40cfaec7ee3bf0423c59925d8b23982a601f1",
+    "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
+    "note": "Pinned because depot_tools resolves every other revision. tools/sync-sources.sh checks this out detached before anything invokes gclient, gn or autoninja."
+  },
+
+  "ungoogled_chromium": {
+    "version": "146.0.7680.177-1",
+    "commit": "ecd0ec03e0d8b1ec59d3b32f3145575ada937490",
+    "url": "https://github.com/ungoogled-software/ungoogled-chromium.git",
+    "ref": "refs/tags/146.0.7680.177-1",
+    "legacy": true,
+    "removal_issue": 8
+  },
+
+  "third_party": {
+    "adblock_rust": {
+      "pinned": false,
+      "reason": "tools/vendor-adblock-rust.sh does not select a revision: it appends an 'adblock' dependency at a caret range to Chromium's third_party/rust/chromium_crates_io/Cargo.toml and lets gnrt resolve it, so there is no revision to record. Pinning it means changing how vendoring works, which affects browser output and belongs to its own change rather than to the lock.",
+      "issue": 5
+    }
+  }
+}

--- a/browser.lock.schema.json
+++ b/browser.lock.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/OxyHQ/Astro/browser.lock.schema.json",
+  "title": "Astro browser source lock",
+  "description": "Declares the exact, immutable revision of every external source that can change browser output. A build reads this file; it never asks a remote what 'latest' means, and never accepts whatever a cached runner happens to hold.\n\nValidated by tools/lib/lock.py, which implements the subset of JSON Schema used here. The schema is the contract; the validator reads it rather than re-stating it, so the two cannot drift.",
+  "type": "object",
+  "required": ["lockfile_version", "chromium", "depot_tools"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Relative path to this schema, for editor tooling."
+    },
+
+    "lockfile_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Format version. Bump when the shape changes incompatibly, so an old tool refuses a new lock instead of misreading it."
+    },
+
+    "chromium": {
+      "type": "object",
+      "description": "The upstream Chromium source. `commit` is authoritative; `version` and `ref` are recorded for humans and for update tooling, and are never used to select what is checked out.",
+      "required": ["version", "commit", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$",
+          "description": "Human-readable Chromium version, e.g. 146.0.7680.177."
+        },
+        "commit": { "$ref": "#/$defs/sha" },
+        "url": { "$ref": "#/$defs/url" },
+        "ref": {
+          "type": "string",
+          "pattern": "^refs/(tags|heads|branch-heads)/.+$",
+          "description": "The ref the commit was resolved FROM, recorded for provenance and for update tooling to re-verify the tag/commit relationship. A moved or retagged ref cannot change a build, because `commit` is what is checked out."
+        }
+      }
+    },
+
+    "depot_tools": {
+      "type": "object",
+      "description": "Pinned because depot_tools resolves every other revision: gclient, gn and autoninja all come from it, so an unconstrained `git pull` here silently changes what every other pin means.",
+      "required": ["commit", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "commit": { "$ref": "#/$defs/sha" },
+        "url": { "$ref": "#/$defs/url" },
+        "note": { "type": "string" }
+      }
+    },
+
+    "ungoogled_chromium": {
+      "type": "object",
+      "description": "Legacy input: the inherited patch stack. Present until the patch system is removed (issue #8), and marked as such so nothing reads its presence as permanent.",
+      "required": ["version", "commit", "url"],
+      "additionalProperties": false,
+      "properties": {
+        "version": { "type": "string", "minLength": 1 },
+        "commit": { "$ref": "#/$defs/sha" },
+        "url": { "$ref": "#/$defs/url" },
+        "ref": {
+          "type": "string",
+          "pattern": "^refs/(tags|heads)/.+$",
+          "description": "The ref the commit was resolved FROM, re-verified by --check-remote."
+        },
+        "legacy": { "type": "boolean" },
+        "removal_issue": { "type": "integer" }
+      }
+    },
+
+    "third_party": {
+      "type": "object",
+      "description": "Every other external source that can change browser output. An entry that is NOT yet pinnable must say so explicitly with pinned:false and a reason, so a gap is declared and greppable rather than absent and invisible.",
+      "additionalProperties": false,
+      "propertyNames": { "pattern": "^[a-z0-9_]+$" },
+      "properties": {
+        "adblock_rust": { "$ref": "#/$defs/thirdPartyEntry" }
+      }
+    }
+  },
+
+  "$defs": {
+    "sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$",
+      "description": "A full 40-character lowercase git commit SHA. Abbreviated SHAs, branch names and tag names are rejected: all three can resolve to different commits over time, which is the entire failure this lock exists to prevent."
+    },
+    "url": {
+      "type": "string",
+      "pattern": "^(https|file)://[^\\s]+$",
+      "description": "The origin the commit came from. A SHA with no origin is not reproducible.\n\nfile:// is permitted for local mirrors and for the test fixtures, which need real git remotes without network access. The repository's own browser.lock.json must use https only, which tools/tests/cases/lock-schema-validation.sh asserts separately — the schema cannot express 'https here, file:// there' without making the fixtures untestable."
+    },
+    "thirdPartyEntry": {
+      "type": "object",
+      "required": ["pinned"],
+      "additionalProperties": false,
+      "properties": {
+        "pinned": { "type": "boolean" },
+        "commit": { "$ref": "#/$defs/sha" },
+        "version": { "type": "string", "minLength": 1 },
+        "url": { "$ref": "#/$defs/url" },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required when pinned is false: why this source cannot be pinned yet, and what would change that."
+        },
+        "issue": {
+          "type": "integer",
+          "description": "The issue that will pin it."
+        }
+      }
+    }
+  }
+}

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -12,7 +12,7 @@ Astro keeps a strict separation between upstream Chromium and Oxy code. There ar
 2. **`src/chrome/browser/oxy/`** — the entire C++ overlay (auth, cookie observer, Alia, ad blocker, WebUI controllers).
 3. **`webui/`** — the Vite + Tailwind frontends for each internal page.
 
-Everything else is stock Chromium, fetched fresh from upstream with `tools/fetch-chromium.sh`. This makes Chromium version bumps tractable — patches rebase cleanly because they are small and the overlay is self-contained.
+Everything else is stock Chromium, checked out at the exact commit `browser.lock.json` declares by `tools/sync-sources.sh`. This makes Chromium version bumps tractable — patches rebase cleanly because they are small and the overlay is self-contained — and makes each bump a reviewable lock diff. See [Reproducibility](/reproducibility).
 
 <Badge>Brave-style overlay</Badge> <Badge>Mojo IPC</Badge> <Badge>Rust adblock FFI</Badge>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -97,7 +97,7 @@ A from-scratch build takes 2-4 hours. The shortest path:
 
 ```sh
 # 1. Fetch Chromium source (~55 GB, 30-90 min depending on link)
-tools/fetch-chromium.sh
+tools/sync-sources.sh
 
 # 2. Sync ungoogled-chromium patches for the current Chromium version
 tools/sync-ungoogled.sh

--- a/docs/reproducibility.mdx
+++ b/docs/reproducibility.mdx
@@ -1,0 +1,281 @@
+---
+title: Reproducibility
+description: The source lock, deterministic sync, and build provenance.
+---
+
+# Reproducibility
+
+Every Astro build starts from an explicitly declared set of source revisions.
+A cached runner never decides which Chromium gets compiled.
+
+Two files carry it:
+
+| File | Role |
+|---|---|
+| [`browser.lock.json`](https://github.com/OxyHQ/Astro/blob/master/browser.lock.json) | What *should* be built — declared, reviewed, committed |
+| `build/reports/provenance.json` | What *was* built — measured from the trees on disk |
+
+They are deliberately produced from different sources. Provenance generated
+from the lock could only ever restate the lock, and would certify a stale
+runner's build as correct.
+
+## The lock
+
+```json
+{
+  "lockfile_version": 1,
+  "chromium": {
+    "version": "146.0.7680.177",
+    "commit": "ae03f7fb2cf1215853896d6a4c15fdceee2badb7",
+    "url": "https://chromium.googlesource.com/chromium/src.git",
+    "ref": "refs/tags/146.0.7680.177"
+  },
+  "depot_tools": { "commit": "…", "url": "…" },
+  "ungoogled_chromium": { "version": "…", "commit": "…", "url": "…", "legacy": true }
+}
+```
+
+`commit` is authoritative. `version` and `ref` are recorded for humans and for
+update tooling; nothing selects a checkout from them, so a moved or retagged
+ref cannot change a build.
+
+Validation is against [`browser.lock.schema.json`](https://github.com/OxyHQ/Astro/blob/master/browser.lock.schema.json):
+
+```sh
+python3 tools/lib/lock.py --validate       # schema + revision listing
+python3 tools/lib/lock.py --check-remote   # do the refs still resolve? (network)
+python3 tools/lib/lock.py --get chromium.commit
+```
+
+Rejected, each with the reason named: abbreviated SHAs, uppercase SHAs, branch
+names, tag names, unknown fields, an unknown `lockfile_version`, and an
+unpinned third-party entry with no stated reason. All of those still *look*
+like revisions, which is why they are worth rejecting explicitly.
+
+<Note>
+**`depot_tools` is pinned, and pinned first.** It provides `gclient`, `gn` and
+`autoninja`, so it resolves what every other pin means. The previous
+implementation ran `cd depot_tools && git pull` on every fetch.
+</Note>
+
+### Two deliberate deviations
+
+**The Astro commit is not in the lock.** A file cannot contain the hash of the
+commit that contains it — the value would be wrong the moment it was written.
+Astro's own revision is resolved at build time and recorded in provenance,
+which is where a self-referential fact belongs.
+
+**`third_party.adblock_rust` is recorded as `"pinned": false`, with a reason.**
+`tools/vendor-adblock-rust.sh` appends an `adblock` dependency at a caret range
+to Chromium's `chromium_crates_io/Cargo.toml` and lets `gnrt` resolve it, so
+there is no revision to record. The schema *requires* a `reason` on any
+unpinned entry, so the gap is declared and greppable rather than absent and
+invisible.
+
+## Synchronising
+
+```sh
+tools/sync-sources.sh                # bring every tree to the locked revision
+tools/sync-sources.sh --verify-only  # never writes; differences are fatal (CI)
+tools/sync-sources.sh --dry-run      # print the plan
+tools/sync-sources.sh --no-deps      # checkout only; skip `gclient sync`
+```
+
+This is the **one** synchronisation command: documentation and CI both run it,
+so there is no second implementation to drift from the documented one.
+`tools/fetch-chromium.sh` is a thin deprecated wrapper that delegates here.
+
+What it guarantees:
+
+- **depot_tools is pinned before anything invokes `gclient`, `gn` or `autoninja`.**
+- **Fetching never changes the selected commit.** Refs are updated; the
+  checkout moves only in an explicit `checkout --detach`.
+- **The checkout is detached at the locked commit.** A branch at the right
+  commit is not enough — a branch can be advanced afterwards, by a stray
+  `git pull`, another job, or gclient, with nothing noticing. A fresh `git
+  clone` lands on a branch, so this is corrected even when the commit is
+  already right.
+- **`.gclient` is rendered from [`tools/gclient.template`](https://github.com/OxyHQ/Astro/blob/master/tools/gclient.template)**,
+  committed configuration rather than a string built per invocation.
+- **`gclient sync` is anchored** with `--revision src@<locked-sha>`, and HEAD
+  is re-verified afterwards in case the sync moved it.
+- **DEPS-resolved revisions are recorded** to `build/reports/deps-revinfo.json`.
+- **A second invocation does no work beyond verification**, and says so.
+
+### Bounding the first fetch
+
+**A failed fetch is not resumable.** Git streams a fetch into a temporary pack
+and discards it when the transfer fails, so every attempt genuinely starts over.
+Measured here: five consecutive failed attempts left `.git` at 120 KB. On a link
+that dropped four times inside the first 220 MB, what made the bootstrap complete
+was bounding what has to arrive in one go — not retrying harder.
+
+| Variable | Default | Effect |
+|---|---|---|
+| `ASTRO_FETCH_DEPTH` | `1` | Fetch the locked commit without its history — one commit's tree instead of tens of gigabytes |
+| `ASTRO_FETCH_FILTER` | `blob:none` | Partial clone: file contents arrive as small on-demand batches during checkout, each failing and retrying independently |
+| `ASTRO_FETCH_ATTEMPTS` | `5` | Bounded, announced retries; the final failure is fatal, not swallowed |
+
+Depth and filter apply only to the **first network fetch into a still-empty
+repository, and only for an `http(s)` origin**. A local `file://` fixture has no
+history worth truncating, and shallow-copying one silently loses the older
+commits a test needs to move between. Deepening an existing checkout is a
+separate operation and is never done implicitly.
+
+Both costs are real, and are stated at the setting rather than discovered later:
+
+- A depth-limited checkout has **no local ancestry**. The commit checked out is
+  still exactly the one the lock names, so nothing about reproducibility changes.
+  `ASTRO_FETCH_DEPTH=` (empty) fetches the full history, which
+  `git fetch --unshallow` can also add later.
+- A blobless checkout **needs network access during the build** to fetch contents
+  it has not seen. `ASTRO_FETCH_FILTER=` (empty) makes the local copy complete.
+
+<Note>
+**Measured on the first real bootstrap.** With the defaults above the checkout
+completed at 6.6 GB with HEAD at `ae03f7fb2cf1215853896d6a4c15fdceee2badb7` — the
+commit `browser.lock.json` names — and
+`tools/sync-sources.sh --verify-only --no-deps` exits 0 against it.
+</Note>
+
+### What it refuses
+
+`--verify-only` is what CI runs before every build, and it fails on:
+
+| State | Why it matters |
+|---|---|
+| Wrong commit | The stale-runner case: a cached checkout compiling an undeclared commit |
+| On a branch | Right commit, but able to move afterwards |
+| Uncommitted changes | The build would include work nobody declared |
+| Untracked `.rej` / `.orig` | A partial patch application survived. Only *untracked* ones count: Chromium ships 181 tracked `.orig` files. See [Recovery](/recovery) |
+| Linked worktrees | Two jobs mutating one shared checkout |
+| `.gclient` ≠ template | Configured differently from what the repository says |
+
+`ASTRO_ALLOW_DIRTY_CHROMIUM=1` overrides the dirty-checkout guard in the
+default mode only. It has **no effect under `--verify-only`** — a CI gate that
+an environment variable can wave through is not a gate — and CI asserts it is
+never set.
+
+## Provenance
+
+`tools/build.sh` generates `build/reports/provenance.json` after every build,
+and the packaging scripts ship it inside every release artifact.
+
+It records: the Chromium commit and version, the Astro commit, depot_tools,
+ungoogled-chromium, third-party revisions, the GN args (literally *and* by
+hash), target platform and build type, host OS and architecture, and the
+compiler path and version. If `GITHUB_RUN_ID` is set it also records the
+workflow, run id, attempt, SHA and ref.
+
+```sh
+tools/generate-provenance.sh --gn-args gn_args/linux.gn --platform linux \
+                             --build-type Release
+tools/generate-provenance.sh --require-match     # release builds
+```
+
+Two fields exist to be read by a human who is suspicious:
+
+- **`drift`** — every source whose on-disk revision differs from the lock.
+- **`dirty_worktrees`** — every source with uncommitted changes.
+
+`reproducible` is true only when both are empty. `--require-match` turns either
+into a non-zero exit, which is what a release build uses: an artifact must
+record revisions somebody can check out again.
+
+<Note>
+**No wall-clock timestamp is recorded as a build input** (`timestamp_policy:
+"excluded-from-build-inputs"`). Embedding one makes two builds of identical
+sources differ, defeating the reproducibility the file exists to record. CI's
+own run metadata carries the "when".
+</Note>
+
+## Changing the Chromium version
+
+```sh
+tools/update-chromium.sh 147.0.7710.20            # propose
+tools/update-chromium.sh 147.0.7710.20 --apply    # propose and sync
+```
+
+It resolves the version to exactly one commit at the origin, checks the
+tag/commit relationship is consistent, updates the lock, and writes a change
+report to `build/reports/`. The default is proposal-only: an update changes
+what the whole project compiles, so it lands as a reviewable lock diff rather
+than as a side effect.
+
+<Warning>
+**No nearby version is ever substituted.** A version with no exact tag fails.
+
+The previous implementation tried the exact tag, then
+`git tag -l "$MAJOR.*" | tail -1`, then `master` — printing a warning and
+exiting **zero**. A "successful" update could therefore build against a patch
+set written for a different Chromium major, and the only trace was a line of
+console output.
+</Warning>
+
+`ungoogled_chromium` is **not** updated automatically. Its tag for a new
+Chromium version is published separately and is not derivable from the Chromium
+version, so guessing it is the same defect in a different place. The command
+warns, and you update the lock deliberately.
+
+### Selecting a security update
+
+1. Identify the release from the [Chrome releases blog](https://chromereleases.googleblog.com/)
+   or [chromiumdash](https://chromiumdash.appspot.com/releases), and note the
+   exact four-part version.
+2. `tools/update-chromium.sh <version>` — resolves it to a commit, updates the
+   lock, writes the report. Review the lock diff.
+3. Update `ungoogled_chromium` in the lock to the matching tag, and confirm the
+   tag exists.
+4. `tools/sync-sources.sh`, then `tools/apply-patches.sh`. Patches that no
+   longer apply exactly stop the run and are named in
+   `build/reports/patch-report.json`; resolve them by regenerating the patch,
+   never by loosening the application. See [Recovery](/recovery).
+5. Open the PR with the lock diff and the change report. The lock diff *is* the
+   review: it is the complete statement of what changed about the sources.
+
+## CI
+
+Every job runs the same two steps, in this order:
+
+```yaml
+- name: Sync sources to the locked revisions
+  run: tools/sync-sources.sh
+
+- name: Verify source revisions against the lock
+  run: tools/sync-sources.sh --verify-only
+```
+
+They are separate on purpose: a sync that silently did nothing still cannot
+produce a build.
+
+Caches are object/download caches only. The previous workflow decided whether
+to synchronise by testing whether `chromium/src/.git` existed —
+
+```yaml
+if [ ! -d "chromium/src/.git" ]; then
+  tools/sync-sources.sh
+else
+  echo "Chromium source cached, skipping fetch"
+fi
+```
+
+— so a self-hosted runner that had ever fetched Chromium compiled whatever
+commit it happened to hold, forever, with nothing validating it. That shape is
+now rejected by `tools/tests/lib/scan-shell-patterns.py`, which scans the
+workflow files as well as the scripts.
+
+A `concurrency` group per workflow and ref prevents two jobs mutating one
+runner's shared checkout at the same time.
+
+## Recovering a local checkout
+
+If your checkout predates the lock:
+
+```sh
+git -C chromium/src status          # review anything you want to keep
+tools/sync-sources.sh               # detaches at the locked commit
+tools/sync-sources.sh --verify-only # confirm
+```
+
+If it refuses because of local changes, that is deliberate — keep or discard
+them, then re-run. [Recovery](/recovery) covers the rest.

--- a/tools/astro-launch.sh
+++ b/tools/astro-launch.sh
@@ -1,41 +1,8 @@
 #!/usr/bin/env bash
-# astro-launch.sh — runtime launcher, installed next to the browser binary.
-#
-# This is the one script in tools/ that is NOT part of the build pipeline: it
-# ships to end users and runs at browser start, standalone, with no access to
-# the repository. So it cannot source tools/lib/astro-common.sh and cannot use
-# astro::optional to classify a best-effort step.
-#
-# Its three tolerated failures are marked individually below with the same
-# `# astro-allow:` mechanism the build scripts use for reviewed exceptions, so
-# they stay visible to the scanner and to review rather than being excluded
-# wholesale.
-
 INSTALL_DIR="$HOME/.local/share/astro"
 DATA_DIR="$HOME/.config/astro"
-PORT=19845
 
-# Kill any existing server on this port. Nothing listening is the normal case
-# on a first launch, and fuser reports that on stderr.
-# astro-allow: no listener is the expected state, not a failure
-fuser -k 19845/tcp 2>/dev/null
-sleep 0.2
+# All pages are served natively via chrome:// URLs.
+# No HTTP server needed.
 
-# Start server on fixed port. Its request log is noise in a browser launcher;
-# a real startup failure surfaces as the page failing to load below.
-# astro-allow: backgrounded helper server, request log is not diagnostic output
-python3 -m http.server $PORT -d "$INSTALL_DIR/resources" --bind 127.0.0.1 &>/dev/null &
-SERVER_PID=$!
-sleep 0.3
-
-NTP="http://127.0.0.1:$PORT/astro-ntp/index.html"
-
-if [ $# -eq 0 ]; then
-    "$INSTALL_DIR/chrome" --no-sandbox --user-data-dir="$DATA_DIR" "$NTP"
-else
-    "$INSTALL_DIR/chrome" --no-sandbox --user-data-dir="$DATA_DIR" "$@"
-fi
-
-# Cleanup after the browser exits. The server may already be gone.
-# astro-allow: best-effort cleanup of an already-possibly-dead helper
-kill $SERVER_PID 2>/dev/null
+"$INSTALL_DIR/chrome" --no-sandbox --user-data-dir="$DATA_DIR" "$@"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -98,6 +98,21 @@ astro::resolve_chromium_src ""
 CHROMIUM_SRC="$ASTRO_RESOLVED_CHROMIUM_SRC"
 astro::info "Checkout:   $CHROMIUM_SRC"
 
+# The checkout must be at the revision browser.lock.json declares. Without this
+# gate a stale tree — a self-hosted runner's cache, a local experiment left
+# checked out — compiles silently and the resulting binary claims to be
+# something it is not. ASTRO_SKIP_LOCK_VERIFY exists for bisecting an upstream
+# regression, where being deliberately off-lock is the entire point; it prints
+# a structured warning and lands in the provenance file as drift.
+if [ "${ASTRO_SKIP_LOCK_VERIFY:-0}" = "1" ]; then
+    astro::warn "override:skip-lock-verify" \
+        "building without verifying source revisions against browser.lock.json"
+else
+    astro::info ">>> Verifying source revisions against browser.lock.json..."
+    "$ASTRO_ROOT/tools/sync-sources.sh" --verify-only --no-deps \
+        --chromium-src "$CHROMIUM_SRC"
+fi
+
 case "$PLATFORM" in
     linux)
         if [ "$BUILD_TYPE" = "Debug" ]; then
@@ -263,6 +278,25 @@ else
     rsync -a "$ADBLOCK_RESOURCES/" "$BUILD_OUT/adblock_resources/"
 fi
 
+# --------------------------------------------------------------------------
+# Provenance — what this build was actually made from
+#
+# Generated from the trees on disk, not from the lock, so a build that drifted
+# says so instead of restating what it was supposed to be.
+# --------------------------------------------------------------------------
+
+if astro::dry_run; then
+    astro::plan "generate build/reports/provenance.json"
+else
+    # The overlay manifest is the only record of whether the copied overlay
+    # came from the commit being built, so provenance is pointed at the one
+    # this run's sync-overlay wrote rather than left to find it by default.
+    "$ASTRO_ROOT/tools/generate-provenance.sh" \
+        --gn-args "$GN_ARGS_FILE" \
+        --platform "$PLATFORM" \
+        --build-type "$BUILD_TYPE" \
+        --overlay-manifest "$ASTRO_REPORT_DIR/overlay-manifest.json"
+fi
 
 astro::info "=== Build complete ==="
 astro::info "Platform: $PLATFORM"

--- a/tools/fetch-chromium.sh
+++ b/tools/fetch-chromium.sh
@@ -1,112 +1,53 @@
 #!/usr/bin/env bash
+# fetch-chromium.sh — DEPRECATED. Use tools/sync-sources.sh.
+#
+# This script used to decide, on its own, which Chromium got compiled: it read
+# CHROMIUM_VERSION from its own default, ran an unconstrained `git pull` in
+# depot_tools, string-built .gclient per invocation, and checked Chromium out
+# onto a BRANCH (`git checkout tags/$VERSION -B astro-$VERSION`) that could
+# drift afterwards with nothing noticing.
+#
+# tools/sync-sources.sh replaces all of it: browser.lock.json declares the
+# exact commit of every source, depot_tools is pinned before anything invokes
+# gclient, .gclient is rendered from a committed template, and the checkout is
+# detached at the locked commit and verified afterwards.
+#
+# This wrapper exists so that a documented command, a stale runbook or an old
+# CI job cannot silently reintroduce the previous behaviour. It delegates.
+
 ASTRO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export ASTRO_ROOT
 # shellcheck source=tools/lib/astro-common.sh
 source "$ASTRO_ROOT/tools/lib/astro-common.sh"
-CHROMIUM_DIR="$ASTRO_ROOT/chromium"
-DEPOT_TOOLS_DIR="$ASTRO_ROOT/depot_tools"
 
-# Target Chromium version (update this when rebasing)
-CHROMIUM_VERSION="${CHROMIUM_VERSION:-146.0.7680.177}"
+astro::warn "deprecated:fetch-chromium" \
+    "tools/fetch-chromium.sh is deprecated; delegating to tools/sync-sources.sh"
 
-# Cross-compilation targets: space-separated list of OS targets
-# Supported: linux, win, android, mac
-# Set via env or --targets flag
-CROSS_TARGETS="${CROSS_TARGETS:-linux}"
+if [ -n "${CHROMIUM_VERSION:-}" ]; then
+    LOCKED_VERSION="$(python3 "$ASTRO_ROOT/tools/lib/lock.py" --get chromium.version)"
+    if [ "$CHROMIUM_VERSION" != "$LOCKED_VERSION" ]; then
+        astro::die_with_hint \
+            "CHROMIUM_VERSION=$CHROMIUM_VERSION conflicts with the lock ($LOCKED_VERSION)." \
+            "" \
+            "An environment variable no longer selects what gets compiled — that is" \
+            "the whole point of browser.lock.json. To change version:" \
+            "" \
+            "  tools/update-chromium.sh $CHROMIUM_VERSION" \
+            "" \
+            "which resolves it to an exact commit, updates the lock and writes a" \
+            "change report for review."
+    fi
+fi
 
-# Parse --targets flag
+TARGETS=""
 for arg in "$@"; do
     case "$arg" in
-        --targets=*) CROSS_TARGETS="${arg#*=}" ;;
-        --targets)   shift; CROSS_TARGETS="${1:-linux}" ;;
+        --targets=*) TARGETS="${arg#*=}" ;;
+        *) astro::die "Unknown argument: $arg (tools/sync-sources.sh --help lists the current options)" ;;
     esac
 done
 
-echo "=== Fetching Chromium $CHROMIUM_VERSION ==="
-echo "Target platforms: $CROSS_TARGETS"
-
-# Step 1: Ensure depot_tools is available
-if [ ! -d "$DEPOT_TOOLS_DIR" ]; then
-    echo ">>> Cloning depot_tools..."
-    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git "$DEPOT_TOOLS_DIR"
-else
-    echo ">>> Updating depot_tools..."
-    cd "$DEPOT_TOOLS_DIR" && git pull
+if [ -n "$TARGETS" ]; then
+    exec "$ASTRO_ROOT/tools/sync-sources.sh" --targets "$TARGETS"
 fi
-
-export PATH="$DEPOT_TOOLS_DIR:$PATH"
-
-# Step 2: Create chromium directory and fetch
-mkdir -p "$CHROMIUM_DIR"
-cd "$CHROMIUM_DIR"
-
-if [ ! -f ".gclient" ]; then
-    echo ""
-    echo ">>> Running fetch (this will take a while - ~30GB download)..."
-    fetch --nohooks chromium
-fi
-
-# Step 3: Configure target_os for cross-compilation in .gclient
-# This MUST be set before gclient sync/runhooks so toolchains are downloaded
-echo ""
-echo ">>> Configuring cross-compilation targets..."
-
-# Build target_os list from CROSS_TARGETS
-TARGET_OS_LIST=""
-for target in $CROSS_TARGETS; do
-    case "$target" in
-        linux)   TARGET_OS_LIST="$TARGET_OS_LIST\"linux\", " ;;
-        win)     TARGET_OS_LIST="$TARGET_OS_LIST\"win\", " ;;
-        android) TARGET_OS_LIST="$TARGET_OS_LIST\"android\", " ;;
-        mac)     TARGET_OS_LIST="$TARGET_OS_LIST\"mac\", " ;;
-        *)       echo "WARNING: Unknown target '$target', skipping" ;;
-    esac
-done
-
-# Remove trailing comma+space
-TARGET_OS_LIST="${TARGET_OS_LIST%, }"
-
-# Write .gclient with target_os
-cat > "$CHROMIUM_DIR/.gclient" << GCLIENT_EOF
-solutions = [
-  {
-    "name": "src",
-    "url": "https://chromium.googlesource.com/chromium/src.git",
-    "managed": False,
-    "custom_deps": {},
-    "custom_vars": {},
-  },
-]
-target_os = [$TARGET_OS_LIST]
-GCLIENT_EOF
-
-echo "  .gclient configured with target_os = [$TARGET_OS_LIST]"
-
-# Step 4: Checkout target version
-cd "$CHROMIUM_DIR/src"
-echo ""
-echo ">>> Checking out version $CHROMIUM_VERSION..."
-git checkout "tags/$CHROMIUM_VERSION" -B "astro-$CHROMIUM_VERSION"
-
-# Step 5: Sync dependencies (downloads platform-specific SDKs/toolchains)
-echo ""
-echo ">>> Syncing dependencies (gclient sync)..."
-echo "  This downloads SDKs and toolchains for: $CROSS_TARGETS"
-gclient sync --with_branch_heads --with_tags -D
-
-# Step 6: Run hooks (installs build tools, SDKs, NDK, Windows SDK, etc.)
-# This is where cross-compilation toolchains get downloaded.
-# MUST run BEFORE any de-Googling patches (domain substitution) are applied.
-echo ""
-echo ">>> Running hooks (downloading toolchains)..."
-gclient runhooks
-
-echo ""
-echo "=== Chromium $CHROMIUM_VERSION ready ==="
-echo "Source at: $CHROMIUM_DIR/src"
-echo "Targets: $CROSS_TARGETS"
-echo ""
-echo "Next steps:"
-echo "  1. tools/sync-ungoogled.sh    # Get ungoogled-chromium patches"
-echo "  2. tools/apply-patches.sh     # Apply all patches"
-echo "  3. tools/build.sh             # Build Astro"
+exec "$ASTRO_ROOT/tools/sync-sources.sh"

--- a/tools/gclient.template
+++ b/tools/gclient.template
@@ -1,0 +1,25 @@
+# gclient.template — the committed source of Astro's .gclient file.
+#
+# tools/sync-sources.sh renders this into chromium/.gclient on every sync, and
+# --verify-only fails when the file on disk does not match. The previous
+# implementation string-built .gclient inside fetch-chromium.sh, so the
+# effective configuration depended on which flags that run happened to receive
+# and nothing recorded what a given checkout had been configured with.
+#
+# Placeholders, substituted from browser.lock.json and --targets:
+#   @CHROMIUM_URL@   chromium.url from the lock
+#   @TARGET_OS@      quoted, comma-separated gclient target_os list
+#
+# managed = False is deliberate: gclient must not move the checkout on its own.
+# tools/sync-sources.sh selects the commit, from the lock, and verifies HEAD
+# afterwards.
+solutions = [
+  {
+    "name": "src",
+    "url": "@CHROMIUM_URL@",
+    "managed": False,
+    "custom_deps": {},
+    "custom_vars": {},
+  },
+]
+target_os = [@TARGET_OS@]

--- a/tools/generate-provenance.sh
+++ b/tools/generate-provenance.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# generate-provenance.sh — record exactly what a build was made from.
+#
+# Provenance is read from WHAT IS ON DISK, never from browser.lock.json. The
+# two can disagree — that disagreement is the interesting fact, and this script
+# reports it rather than smoothing it over. A provenance file generated from
+# the lock would only ever restate the lock, and would certify a stale runner
+# as correct.
+#
+# Usage:
+#   tools/generate-provenance.sh [options]
+#
+#   --output FILE     Where to write (default: build/reports/provenance.json)
+#   --gn-args FILE    GN args file used for this build
+#   --platform NAME   Target platform (linux, windows, macos, android, ...)
+#   --build-type NAME Release or Debug
+#   --overlay-manifest FILE
+#                     Manifest written by tools/sync-overlay.sh, which records
+#                     whether the overlay came from the commit being built
+#                     (default: build/reports/overlay-manifest.json)
+#   --require-match   Exit non-zero if any on-disk revision differs from the
+#                     lock, or if the overlay did not come from a commit.
+#                     Release builds use this.
+
+ASTRO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export ASTRO_ROOT
+# shellcheck source=tools/lib/astro-common.sh
+source "$ASTRO_ROOT/tools/lib/astro-common.sh"
+
+LOCK_FILE="$ASTRO_ROOT/browser.lock.json"
+OUTPUT=""
+GN_ARGS_FILE=""
+PLATFORM="unknown"
+BUILD_TYPE="unknown"
+REQUIRE_MATCH=0
+CHROMIUM_SRC_OPT=""
+DEPOT_TOOLS_DIR="$ASTRO_ROOT/depot_tools"
+UNGOOGLED_DIR="$ASTRO_ROOT/.ungoogled-chromium"
+OVERLAY_MANIFEST="$ASTRO_REPORT_DIR/overlay-manifest.json"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --output)        shift; OUTPUT="${1:?--output needs a file}" ;;
+        --gn-args)       shift; GN_ARGS_FILE="${1:?--gn-args needs a file}" ;;
+        --platform)      shift; PLATFORM="${1:?--platform needs a name}" ;;
+        --build-type)    shift; BUILD_TYPE="${1:?--build-type needs a name}" ;;
+        --lock)          shift; LOCK_FILE="${1:?--lock needs a file}" ;;
+        --chromium-src)  shift; CHROMIUM_SRC_OPT="${1:?--chromium-src needs a directory}" ;;
+        --depot-tools)   shift; DEPOT_TOOLS_DIR="${1:?--depot-tools needs a directory}" ;;
+        --ungoogled)     shift; UNGOOGLED_DIR="${1:?--ungoogled needs a directory}" ;;
+        --overlay-manifest) shift; OVERLAY_MANIFEST="${1:?--overlay-manifest needs a file}" ;;
+        --require-match) REQUIRE_MATCH=1 ;;
+        -h|--help)
+            sed -n '2,27p' "${BASH_SOURCE[0]}" >&2
+            exit 0
+            ;;
+        *) astro::die "Unknown argument: $1" ;;
+    esac
+    shift
+done
+
+astro::require_cmd git python3
+astro::require_file "$LOCK_FILE" "lock file"
+
+if [ -z "$OUTPUT" ]; then
+    OUTPUT="$(astro::report_dir)/provenance.json"
+fi
+
+astro::resolve_chromium_src "$CHROMIUM_SRC_OPT"
+CHROMIUM_SRC="$ASTRO_RESOLVED_CHROMIUM_SRC"
+
+# --------------------------------------------------------------------------
+# On-disk revisions
+# --------------------------------------------------------------------------
+
+# Echoes "<commit> <dirty|clean>" for a checkout, or "absent absent".
+disk_revision() {
+    local dir="$1"
+    # Ask git whether this is a work tree rather than testing for a `.git`
+    # DIRECTORY. In a git worktree `.git` is a FILE holding `gitdir: ...`, so
+    # the directory test reported a perfectly good checkout as "absent" and the
+    # provenance then recorded no revision for it at all — measured on this
+    # repository's own branch-surgery worktree, where Astro's own revision came
+    # back absent while `git rev-parse HEAD` answered fine one directory up.
+    if ! git -C "$dir" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        printf 'absent absent\n'
+        return 0
+    fi
+    local commit state
+    commit="$(git -C "$dir" rev-parse HEAD)"
+    if [ -n "$(git -C "$dir" status --porcelain --untracked-files=no)" ]; then
+        state="dirty"
+    else
+        state="clean"
+    fi
+    printf '%s %s\n' "$commit" "$state"
+}
+
+read -r CHROMIUM_DISK CHROMIUM_STATE <<< "$(disk_revision "$CHROMIUM_SRC")"
+read -r DEPOT_DISK DEPOT_STATE <<< "$(disk_revision "$DEPOT_TOOLS_DIR")"
+read -r UNGOOGLED_DISK UNGOOGLED_STATE <<< "$(disk_revision "$UNGOOGLED_DIR")"
+read -r ASTRO_DISK ASTRO_STATE <<< "$(disk_revision "$ASTRO_ROOT")"
+
+# --------------------------------------------------------------------------
+# Toolchain identity
+#
+# The compiler is part of the build's identity: the same sources with a
+# different clang produce a different binary.
+# --------------------------------------------------------------------------
+
+COMPILER_PATH="$CHROMIUM_SRC/third_party/llvm-build/Release+Asserts/bin/clang++"
+if [ -x "$COMPILER_PATH" ]; then
+    COMPILER_VERSION="$("$COMPILER_PATH" --version | head -1)"
+elif command -v clang++ >/dev/null; then
+    COMPILER_PATH="$(command -v clang++)"
+    COMPILER_VERSION="$(clang++ --version | head -1)"
+    astro::warn "optional:hermetic-compiler" \
+        "Chromium's bundled clang not found; recording the system compiler at $COMPILER_PATH"
+else
+    COMPILER_PATH="unknown"
+    COMPILER_VERSION="unknown"
+    astro::warn "optional:hermetic-compiler" "no clang++ found; compiler identity is unknown"
+fi
+
+HOST_ARCH="$(uname -m)"
+HOST_OS="$(uname -s)"
+
+# --------------------------------------------------------------------------
+# Emit
+# --------------------------------------------------------------------------
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+python3 - \
+    "$OUTPUT" "$LOCK_FILE" "$ASTRO_ROOT/tools/lib/lock.py" \
+    "$CHROMIUM_SRC" "$CHROMIUM_DISK" "$CHROMIUM_STATE" \
+    "$DEPOT_DISK" "$DEPOT_STATE" \
+    "$UNGOOGLED_DISK" "$UNGOOGLED_STATE" \
+    "$ASTRO_DISK" "$ASTRO_STATE" \
+    "$PLATFORM" "$BUILD_TYPE" "$GN_ARGS_FILE" \
+    "$COMPILER_PATH" "$COMPILER_VERSION" "$HOST_OS" "$HOST_ARCH" \
+    "$REQUIRE_MATCH" "$OVERLAY_MANIFEST" <<'PY'
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+
+(output, lock_path, lock_module_path, chromium_src, chromium_disk,
+ chromium_state, depot_disk, depot_state, ungoogled_disk, ungoogled_state,
+ astro_disk, astro_state, platform, build_type, gn_args_file, compiler_path,
+ compiler_version, host_os, host_arch, require_match,
+ overlay_manifest_path) = sys.argv[1:22]
+
+spec = importlib.util.spec_from_file_location("astro_lock", lock_module_path)
+lock_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lock_module)
+
+lock = lock_module.load_validated(
+    __import__("pathlib").Path(lock_path),
+    __import__("pathlib").Path(lock_path).parent / "browser.lock.schema.json",
+)
+
+def locked(name):
+    entry = lock.get(name)
+    return entry["commit"] if entry else None
+
+sources = {
+    "chromium": {
+        "locked": locked("chromium"),
+        "on_disk": chromium_disk,
+        "worktree": chromium_state,
+        "version": lock["chromium"]["version"],
+        "path": chromium_src,
+    },
+    "depot_tools": {
+        "locked": locked("depot_tools"),
+        "on_disk": depot_disk,
+        "worktree": depot_state,
+    },
+    "ungoogled_chromium": {
+        "locked": locked("ungoogled_chromium"),
+        "on_disk": ungoogled_disk,
+        "worktree": ungoogled_state,
+    },
+    # Astro's own revision is resolved here rather than recorded in the lock:
+    # a file cannot contain the hash of the commit that contains it.
+    "astro": {
+        "locked": None,
+        "on_disk": astro_disk,
+        "worktree": astro_state,
+    },
+}
+
+third_party = {}
+for name, entry in lock.get("third_party", {}).items():
+    third_party[name] = {
+        "pinned": entry.get("pinned", False),
+        "commit": entry.get("commit"),
+        "reason": entry.get("reason"),
+    }
+
+drift = [
+    f"{name}: locked {info['locked']}, on disk {info['on_disk']}"
+    for name, info in sources.items()
+    if info["locked"] and info["on_disk"] != info["locked"]
+]
+dirty = [name for name, info in sources.items() if info["worktree"] == "dirty"]
+
+# --------------------------------------------------------------------------
+# Overlay state
+#
+# The overlay is Astro's own contribution to the build, and it is COPIED from
+# the working tree rather than checked out, so the Astro revision recorded
+# above does not describe it: an untracked file under src/ is invisible to
+# `git status --untracked-files=no`, and an ignored one is invisible to git
+# status entirely, yet both are copied into Chromium.
+#
+# tools/sync-overlay.sh measures it and records the verdict; this reads that
+# record. A missing or unreadable manifest is reported as "unmeasured", never
+# as "clean" — a check whose pass and whose nothing-was-measured look the same
+# certifies nothing.
+# --------------------------------------------------------------------------
+
+overlay = {
+    "manifest": overlay_manifest_path,
+    "state": "unmeasured",
+    "clean": False,
+    "revision": None,
+    "override": False,
+    "reason": (
+        f"no overlay manifest at {overlay_manifest_path}; "
+        "tools/sync-overlay.sh did not run for this build"
+    ),
+    "differences": [],
+}
+
+try:
+    with open(overlay_manifest_path, encoding="utf-8") as handle:
+        overlay_manifest = json.load(handle)
+except FileNotFoundError:
+    pass
+except (json.JSONDecodeError, OSError) as error:
+    overlay["reason"] = f"overlay manifest {overlay_manifest_path} is unreadable: {error}"
+else:
+    recorded = overlay_manifest.get("source_state")
+    if not isinstance(recorded, dict):
+        overlay["reason"] = (
+            f"{overlay_manifest_path} records no source_state; it was written by an "
+            "older tools/sync-overlay.sh"
+        )
+    else:
+        overlay.update(
+            {
+                "state": recorded.get("state", "unmeasured"),
+                "clean": bool(recorded.get("clean")),
+                "revision": recorded.get("revision"),
+                "override": bool(recorded.get("override")),
+                "reason": recorded.get("reason"),
+                "differences": recorded.get("differences", []),
+            }
+        )
+
+not_reproducible = []
+not_reproducible += [f"source drift — {line}" for line in drift]
+not_reproducible += [f"dirty worktree — {name} has uncommitted changes" for name in dirty]
+
+if overlay["state"] == "dirty":
+    listed = ", ".join(
+        f"{entry.get('overlay_path')} ({entry.get('classification')})"
+        for entry in overlay["differences"]
+    )
+    not_reproducible.append(
+        f"dirty overlay — {len(overlay['differences'])} overlay path(s) differ from "
+        f"HEAD {overlay['revision']}: {listed}"
+    )
+elif overlay["state"] != "clean":
+    not_reproducible.append(f"overlay {overlay['state']} — {overlay['reason']}")
+
+gn_args = None
+if gn_args_file and os.path.isfile(gn_args_file):
+    with open(gn_args_file, encoding="utf-8") as handle:
+        content = handle.read()
+    gn_args = {
+        "path": gn_args_file,
+        "sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        # The literal args, not just a hash: a hash proves two builds match but
+        # does not tell anyone what either was built with.
+        "args": [
+            line.strip() for line in content.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ],
+    }
+
+document = {
+    "schema": "astro-provenance/1",
+    "sources": sources,
+    "third_party": third_party,
+    "target": {"platform": platform, "build_type": build_type},
+    "host": {"os": host_os, "arch": host_arch},
+    "toolchain": {"compiler": compiler_path, "compiler_version": compiler_version},
+    "gn_args": gn_args,
+    # Timestamps are deliberately excluded from the build inputs: embedding a
+    # wall-clock time makes two builds of identical sources differ, which
+    # defeats the reproducibility this file exists to record. CI's own run
+    # metadata below carries the "when" instead.
+    "timestamp_policy": "excluded-from-build-inputs",
+    "ci": {
+        "workflow": os.environ.get("GITHUB_WORKFLOW"),
+        "run_id": os.environ.get("GITHUB_RUN_ID"),
+        "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "sha": os.environ.get("GITHUB_SHA"),
+        "ref": os.environ.get("GITHUB_REF"),
+    } if os.environ.get("GITHUB_RUN_ID") else None,
+    "drift": drift,
+    "dirty_worktrees": dirty,
+    "overlay": overlay,
+    # A single machine-readable verdict, plus the reasons behind it in the
+    # same document. tools/package-release.sh reads these rather than
+    # re-deriving them, so one place decides what "reproducible" means.
+    "reproducible": not not_reproducible,
+    "not_reproducible_because": not_reproducible,
+}
+
+with open(output, "w", encoding="utf-8") as handle:
+    json.dump(document, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+
+for line in drift:
+    print(f"DRIFT {line}", file=sys.stderr)
+for name in dirty:
+    print(f"DIRTY {name} has uncommitted changes", file=sys.stderr)
+for line in not_reproducible:
+    print(f"NOT-REPRODUCIBLE {line}", file=sys.stderr)
+
+if require_match == "1" and not_reproducible:
+    print("\nERROR --require-match: this build is not reproducible.", file=sys.stderr)
+    for line in not_reproducible:
+        print(f"      {line}", file=sys.stderr)
+    if drift or dirty:
+        print(
+            "      This build does not correspond to the lock. A release artifact must\n"
+            "      record revisions that can be checked out again. Run\n"
+            "      tools/sync-sources.sh, or commit the local changes.",
+            file=sys.stderr,
+        )
+    if not overlay["clean"]:
+        print(
+            "      The overlay this build was made from did not come from a commit, so\n"
+            "      the artifact cannot be reproduced from any revision. Commit the\n"
+            "      overlay changes and rebuild.",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+PY
+
+astro::info "Provenance: $OUTPUT"

--- a/tools/lib/lock.py
+++ b/tools/lib/lock.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Read and validate browser.lock.json — Astro's source revision lock.
+
+The lock declares the exact immutable revision of every external source that
+can change browser output. A build reads it; it never asks a remote what
+"latest" means, and never accepts whatever a cached runner happens to hold.
+
+Validation reads `browser.lock.schema.json` rather than re-stating its rules,
+so the schema is the contract and the two cannot drift. Only the JSON Schema
+subset the lock actually uses is implemented — a partial validator that says
+so beats a dependency on `jsonschema`, which would have to be installed on
+every clean machine and CI runner before the lock could be checked at all.
+
+Usage:
+    lock.py --validate [LOCK]              Validate against the schema.
+    lock.py --get PATH [LOCK]              Print one value, e.g. chromium.commit
+    lock.py --get-optional PATH [LOCK]     Same, but print nothing and exit 0
+                                           when the field is absent.
+    lock.py --revisions [LOCK]             Print `name<TAB>revision` for each.
+    lock.py --check-remote [LOCK]          Verify each commit exists at its
+                                           origin (needs network).
+
+LOCK defaults to browser.lock.json beside this script's repository root.
+Exits non-zero on any failure, and names what failed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_LOCK = REPO_ROOT / "browser.lock.json"
+DEFAULT_SCHEMA = REPO_ROOT / "browser.lock.schema.json"
+
+
+class LockError(Exception):
+    """A lock file problem, phrased for whoever has to fix it."""
+
+
+# ---------------------------------------------------------------------------
+# Minimal JSON Schema validation
+# ---------------------------------------------------------------------------
+
+SUPPORTED_KEYWORDS = {
+    "$schema", "$id", "$ref", "$defs", "title", "description",
+    "type", "required", "properties", "additionalProperties",
+    "propertyNames", "pattern", "const", "enum", "minLength", "items",
+}
+
+TYPE_MAP = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "integer": int,
+    "boolean": bool,
+    "number": (int, float),
+}
+
+
+def resolve_ref(schema: dict, root: dict) -> dict:
+    """Follow a local $ref. Only in-document refs are used by this schema."""
+    ref = schema["$ref"]
+    if not ref.startswith("#/"):
+        raise LockError(f"schema uses an unsupported external $ref: {ref}")
+    node = root
+    for part in ref[2:].split("/"):
+        node = node[part]
+    return node
+
+
+def validate_node(value, schema: dict, root: dict, path: str, errors: list[str]) -> None:
+    if "$ref" in schema:
+        validate_node(value, resolve_ref(schema, root), root, path, errors)
+        return
+
+    # A keyword this validator does not implement must be loud, not ignored:
+    # silently skipping a constraint makes the schema look enforced when it is
+    # not, which is worse than having no validator.
+    for keyword in schema:
+        if keyword not in SUPPORTED_KEYWORDS:
+            errors.append(
+                f"{path}: schema uses '{keyword}', which tools/lib/lock.py does "
+                f"not implement. Implement it or stop using it — a skipped "
+                f"constraint is an unenforced one."
+            )
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        python_type = TYPE_MAP[expected_type]
+        # bool is a subclass of int in Python; an integer field must not
+        # silently accept true.
+        if expected_type == "integer" and isinstance(value, bool):
+            errors.append(f"{path}: expected integer, got boolean")
+            return
+        if not isinstance(value, python_type):
+            errors.append(
+                f"{path}: expected {expected_type}, got {type(value).__name__}"
+            )
+            return
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{path}: expected {schema['const']!r}, got {value!r}")
+
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{path}: {value!r} is not one of {schema['enum']!r}")
+
+    if isinstance(value, str):
+        pattern = schema.get("pattern")
+        if pattern and not re.fullmatch(pattern, value):
+            errors.append(
+                f"{path}: {value!r} does not match {pattern}"
+                + _explain(path, pattern, value)
+            )
+        minimum_length = schema.get("minLength")
+        if minimum_length is not None and len(value) < minimum_length:
+            errors.append(f"{path}: must be at least {minimum_length} character(s)")
+
+    if isinstance(value, dict):
+        for required in schema.get("required", []):
+            if required not in value:
+                errors.append(f"{path}: missing required field '{required}'")
+
+        properties = schema.get("properties", {})
+        names_schema = schema.get("propertyNames")
+        allow_extra = schema.get("additionalProperties", True)
+
+        for key, child in value.items():
+            child_path = f"{path}.{key}" if path else key
+            if names_schema is not None:
+                validate_node(key, names_schema, root, f"{child_path} (name)", errors)
+            if key in properties:
+                validate_node(child, properties[key], root, child_path, errors)
+            elif allow_extra is False:
+                errors.append(f"{child_path}: unexpected field")
+            elif isinstance(allow_extra, dict):
+                validate_node(child, allow_extra, root, child_path, errors)
+
+    if isinstance(value, list) and "items" in schema:
+        for index, item in enumerate(value):
+            validate_node(item, schema["items"], root, f"{path}[{index}]", errors)
+
+
+def _explain(path: str, pattern: str, value: str) -> str:
+    """Turn a pattern mismatch into the reason it matters."""
+    if pattern == "^[0-9a-f]{40}$":
+        if re.fullmatch(r"[0-9a-fA-F]{7,39}", value):
+            return (
+                "\n      An abbreviated SHA is not acceptable: abbreviations are "
+                "not stable as a repository grows, and two objects can share a "
+                "prefix. Record the full 40 characters."
+            )
+        if re.fullmatch(r"[0-9a-fA-F]{40}", value):
+            return "\n      Use lowercase hex."
+        return (
+            "\n      This looks like a branch or tag name. Both can be moved or "
+            "retagged to point at a different commit, which is exactly the "
+            "failure this lock exists to prevent. Record the resolved commit."
+        )
+    return ""
+
+
+def validate(lock: dict, schema: dict) -> list[str]:
+    errors: list[str] = []
+    validate_node(lock, schema, schema, "", errors)
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def load_json(path: Path, what: str) -> dict:
+    if not path.is_file():
+        raise LockError(f"{what} not found: {path}")
+    try:
+        with path.open(encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError as error:
+        raise LockError(f"{what} is not valid JSON: {path}\n      {error}") from error
+
+
+def load_validated(lock_path: Path, schema_path: Path) -> dict:
+    lock = load_json(lock_path, "lock file")
+    schema = load_json(schema_path, "lock schema")
+    errors = validate(lock, schema)
+    if errors:
+        raise LockError(
+            "lock file does not satisfy %s:\n%s"
+            % (schema_path.name, "\n".join("    - " + e for e in errors))
+        )
+    return lock
+
+
+# ---------------------------------------------------------------------------
+# Accessors
+# ---------------------------------------------------------------------------
+
+def revisions(lock: dict) -> list[tuple[str, str]]:
+    """(name, revision) for every locked source, in a stable order.
+
+    Unpinned third-party entries are included, reported as unpinned, so they
+    appear in every revision listing rather than being invisible.
+    """
+    result: list[tuple[str, str]] = []
+    for name in ("chromium", "depot_tools", "ungoogled_chromium"):
+        entry = lock.get(name)
+        if entry:
+            result.append((name, entry["commit"]))
+    for name, entry in sorted(lock.get("third_party", {}).items()):
+        if entry.get("pinned"):
+            result.append((f"third_party.{name}", entry["commit"]))
+        else:
+            result.append((f"third_party.{name}", "UNPINNED"))
+    return result
+
+
+def get_path(lock: dict, dotted: str):
+    node = lock
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            raise LockError(f"no such field in lock: {dotted}")
+        node = node[part]
+    return node
+
+
+def check_remote(lock: dict) -> list[str]:
+    """Verify each locked ref still resolves to its locked commit.
+
+    Needs network.
+
+    An ANNOTATED tag must be peeled before comparing. `git ls-remote` reports
+    `refs/tags/X` as the tag *object* and `refs/tags/X^{}` as the commit it
+    points at; a lightweight tag has no `^{}` line at all. Comparing against
+    the unpeeled line reports permanent, bogus drift for every annotated tag —
+    verified against ungoogled-chromium's `146.0.7680.177-1`, whose tag object
+    is 87bc3cfe while the commit is ecd0ec03. A check that cries wolf on
+    correct data is a check somebody disables, so this peels first.
+    """
+    problems: list[str] = []
+    for name in ("chromium", "depot_tools", "ungoogled_chromium"):
+        entry = lock.get(name)
+        if not entry:
+            continue
+        url, commit = entry["url"], entry["commit"]
+        ref = entry.get("ref")
+        if not ref:
+            continue
+        completed = subprocess.run(
+            ["git", "ls-remote", url, ref, ref + "^{}"],
+            capture_output=True, text=True, timeout=120, check=False,
+        )
+        if completed.returncode != 0:
+            problems.append(f"{name}: could not query {url}: {completed.stderr.strip()}")
+            continue
+
+        advertised: dict[str, str] = {}
+        for line in completed.stdout.splitlines():
+            if not line.strip():
+                continue
+            sha, _, refname = line.partition("\t")
+            advertised[refname.strip()] = sha.strip()
+
+        if not advertised:
+            problems.append(f"{name}: {ref} does not exist at {url}")
+            continue
+
+        # Peeled value when the tag is annotated, direct value otherwise.
+        resolved = advertised.get(ref + "^{}") or advertised.get(ref)
+        if resolved != commit:
+            problems.append(
+                f"{name}: {ref} now resolves to {resolved}, but the lock records "
+                f"{commit}. The ref was moved or retagged. The lock still pins the "
+                f"reviewed commit, which is correct — but the mismatch is worth a "
+                f"deliberate decision."
+            )
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    mode = argv[1]
+    rest = argv[2:]
+
+    if mode in ("--get", "--get-optional"):
+        if not rest:
+            print(f"{mode} needs a dotted path, e.g. chromium.commit", file=sys.stderr)
+            return 2
+        dotted, rest = rest[0], rest[1:]
+    else:
+        dotted = ""
+
+    lock_path = Path(rest[0]) if rest else DEFAULT_LOCK
+    schema_path = (
+        Path(rest[1]) if len(rest) > 1
+        else lock_path.parent / DEFAULT_SCHEMA.name
+    )
+
+    try:
+        lock = load_validated(lock_path, schema_path)
+
+        if mode == "--validate":
+            print(f"{lock_path.name}: valid against {schema_path.name}")
+            for name, revision in revisions(lock):
+                print(f"  {name:26} {revision}")
+            return 0
+
+        if mode == "--get":
+            print(get_path(lock, dotted))
+            return 0
+
+        if mode == "--get-optional":
+            # Absent is a valid answer here, so it is not an error. It is a
+            # separate mode rather than a flag on --get so that a caller who
+            # believes a field is required still fails when it is missing.
+            try:
+                print(get_path(lock, dotted))
+            except LockError:
+                pass
+            return 0
+
+        if mode == "--revisions":
+            for name, revision in revisions(lock):
+                print(f"{name}\t{revision}")
+            return 0
+
+        if mode == "--check-remote":
+            problems = check_remote(lock)
+            if problems:
+                for problem in problems:
+                    print(f"ERROR {problem}", file=sys.stderr)
+                return 1
+            print("every locked ref still resolves to its locked commit")
+            return 0
+
+        print(f"unknown mode: {mode}", file=sys.stderr)
+        return 2
+
+    except LockError as error:
+        print(f"ERROR {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tools/sync-sources.sh
+++ b/tools/sync-sources.sh
@@ -1,0 +1,604 @@
+#!/usr/bin/env bash
+# sync-sources.sh — bring every source tree to exactly the revision
+# browser.lock.json declares, or fail saying which one disagrees.
+#
+# This is the ONE synchronization command. Documentation and CI both run it,
+# so there is no second implementation that can drift from the documented one.
+#
+# What it replaces (ASTRO-NEXT-002, issue #5):
+#
+#   * `cd depot_tools && git pull` — an unconstrained pull of the tool that
+#     resolves every other revision, so it silently changed what every other
+#     pin meant.
+#   * `git checkout "tags/$VERSION" -B "astro-$VERSION"` — created a BRANCH,
+#     so the checkout could drift away from the tag afterwards and nothing
+#     would notice. The locked commit is now checked out detached.
+#   * CI's `if [ ! -d chromium/src/.git ]; then fetch; else echo cached; fi` —
+#     a self-hosted runner that had ever fetched Chromium compiled whatever
+#     commit it happened to hold, forever, unvalidated.
+#
+# Usage:
+#   tools/sync-sources.sh [options]
+#
+#   (no options)     Bring every tree to the locked revision.
+#   --verify-only    Never write. Fail if anything differs from the lock.
+#                    This is what CI runs before every build.
+#   --dry-run        Print the plan; change nothing.
+#   --no-deps        Check out sources but do not run `gclient sync`.
+#
+# A second invocation does no work beyond verification.
+
+ASTRO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export ASTRO_ROOT
+# shellcheck source=tools/lib/astro-common.sh
+source "$ASTRO_ROOT/tools/lib/astro-common.sh"
+
+LOCK_FILE="$ASTRO_ROOT/browser.lock.json"
+# ASTRO_CHROMIUM_SRC is honoured here as well as in
+# astro::resolve_chromium_src: two defaults that can disagree is a bug waiting
+# for whoever exports the variable.
+CHROMIUM_SRC="${ASTRO_CHROMIUM_SRC:-$ASTRO_ROOT/chromium/src}"
+CHROMIUM_DIR="$(dirname "$CHROMIUM_SRC")"
+DEPOT_TOOLS_DIR="$ASTRO_ROOT/depot_tools"
+UNGOOGLED_DIR="$ASTRO_ROOT/.ungoogled-chromium"
+GCLIENT_TEMPLATE="$ASTRO_ROOT/tools/gclient.template"
+
+VERIFY_ONLY=0
+RUN_DEPS=1
+TARGET_OS_LIST="${CROSS_TARGETS:-linux}"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: tools/sync-sources.sh [options]
+
+  --verify-only        Never write; fail if anything differs from the lock.
+  --dry-run            Print the plan; change nothing.
+  --no-deps            Check out sources but skip `gclient sync`.
+  --lock FILE          Lock file (default: browser.lock.json)
+  --chromium-src DIR   Chromium checkout (default: <repo>/chromium/src)
+  --depot-tools DIR    depot_tools checkout
+  --ungoogled DIR      ungoogled-chromium checkout
+  --targets LIST       Space-separated gclient target_os (default: linux)
+  -h, --help
+
+Environment:
+  ASTRO_ALLOW_DIRTY_CHROMIUM=1   Developer-only override for the unrelated
+                                 local-changes guard. Never set in CI.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --verify-only)   VERIFY_ONLY=1 ;;
+        --dry-run)       ASTRO_DRY_RUN=1 ;;
+        --no-deps)       RUN_DEPS=0 ;;
+        --lock)          shift; LOCK_FILE="${1:?--lock needs a file}" ;;
+        --chromium-src)  shift; CHROMIUM_SRC="${1:?--chromium-src needs a directory}"
+                         CHROMIUM_DIR="$(dirname "$CHROMIUM_SRC")" ;;
+        --depot-tools)   shift; DEPOT_TOOLS_DIR="${1:?--depot-tools needs a directory}" ;;
+        --ungoogled)     shift; UNGOOGLED_DIR="${1:?--ungoogled needs a directory}" ;;
+        --targets)       shift; TARGET_OS_LIST="${1:?--targets needs a list}" ;;
+        -h|--help)       usage; exit 0 ;;
+        *)               usage; astro::die "Unknown argument: $1" ;;
+    esac
+    shift
+done
+
+astro::require_cmd git python3
+
+LOCK="$ASTRO_ROOT/tools/lib/lock.py"
+astro::require_file "$LOCK" "lock reader"
+astro::require_file "$LOCK_FILE" "lock file"
+
+# --------------------------------------------------------------------------
+# The lock is validated before anything else looks at it. An invalid lock is
+# not a thing to partially act on.
+# --------------------------------------------------------------------------
+
+astro::info "=== Astro source sync ==="
+if astro::dry_run; then
+    astro::info "Mode: DRY RUN (no filesystem changes)"
+elif [ "$VERIFY_ONLY" = "1" ]; then
+    astro::info "Mode: VERIFY ONLY (no filesystem changes; differences are fatal)"
+fi
+
+python3 "$LOCK" --validate "$LOCK_FILE" >&2
+
+lock_get() {
+    python3 "$LOCK" --get "$1" "$LOCK_FILE"
+}
+
+# `ref` is optional: depot_tools is pinned to a commit on a moving branch and
+# has no stable ref to record. A missing optional field is not an error.
+lock_get_optional() {
+    python3 "$LOCK" --get-optional "$1" "$LOCK_FILE"
+}
+
+CHROMIUM_COMMIT="$(lock_get chromium.commit)"
+CHROMIUM_VERSION="$(lock_get chromium.version)"
+CHROMIUM_URL="$(lock_get chromium.url)"
+CHROMIUM_REF="$(lock_get_optional chromium.ref)"
+DEPOT_TOOLS_COMMIT="$(lock_get depot_tools.commit)"
+DEPOT_TOOLS_URL="$(lock_get depot_tools.url)"
+UNGOOGLED_COMMIT="$(lock_get ungoogled_chromium.commit)"
+UNGOOGLED_URL="$(lock_get ungoogled_chromium.url)"
+UNGOOGLED_REF="$(lock_get_optional ungoogled_chromium.ref)"
+
+# --------------------------------------------------------------------------
+# Bringing one repository to a locked commit
+# --------------------------------------------------------------------------
+
+# Rejects the states a cached self-hosted runner accumulates. Each is reported
+# separately: "something is wrong with the checkout" is not actionable.
+assert_checkout_is_clean_enough() {
+    local dir="$1" name="$2"
+    local problems=""
+
+    # A patched tree is the NORMAL state at build time: the pipeline itself put
+    # 3,923 modifications there. So "is it unmodified" is the wrong question
+    # once patches have been applied — the right one is "is every modification
+    # one Astro made", which is what the patch report answers.
+    #
+    # This distinction only showed up against a real checkout: build.sh gates on
+    # --verify-only, and a pristine requirement made a correctly patched tree
+    # unbuildable.
+    local dirty
+    dirty="$(git -C "$dir" status --porcelain --untracked-files=all)"
+    if [ -n "$dirty" ]; then
+        local count
+        count="$(printf '%s\n' "$dirty" | wc -l | tr -d '[:space:]')"
+        if [ -f "$ASTRO_REPORT_DIR/patch-report.json" ]; then
+            # Dies naming the paths if any are unaccounted for.
+            astro::require_attributable_chromium \
+                "$dir" "$ASTRO_ROOT/tools/overlay.allowlist" \
+                "$ASTRO_REPORT_DIR/patch-report.json" \
+                "$ASTRO_REPORT_DIR/overlay-manifest.json"
+        else
+            problems="$problems
+  $count uncommitted change(s) or untracked file(s), and no patch report to attribute them to"
+        fi
+    fi
+
+    # Only UNTRACKED .rej/.orig files are patch artifacts. Chromium itself ships
+    # 181 tracked `.orig` files — cargo writes `Cargo.toml.orig` for every
+    # vendored Rust crate — so a `find`-based check reports a pristine upstream
+    # checkout as full of leftover artifacts. Measured on the real tree: 181
+    # tracked `.orig`, 0 tracked `.rej`, 0 untracked of either.
+    #
+    # Asking git also avoids walking 400,000 files, and avoids the SIGPIPE that
+    # `find … | head` raises under pipefail once head has what it needs.
+    local artifacts
+    artifacts="$(git -C "$dir" status --porcelain --untracked-files=all \
+        | sed -n 's/^?? //p' | grep -E '\.(rej|orig|porig)$' | head -5)" || true   # astro-allow:suppressed-failure grep finding nothing is the normal case
+    if [ -n "$artifacts" ]; then
+        problems="$problems
+  leftover patch artifacts: $(printf '%s' "$artifacts" | tr '\n' ' ')"
+    fi
+
+    # grep -c exits 1 when the count is zero, which cannot happen here (a
+    # checkout always lists itself) but must not be swallowed if it ever does.
+    local worktrees grep_status=0
+    worktrees="$(git -C "$dir" worktree list --porcelain | grep -c '^worktree ')" || grep_status=$?
+    if [ "$grep_status" -gt 1 ]; then
+        astro::die "could not enumerate worktrees of $dir (grep exit $grep_status)"
+    fi
+    if [ "$worktrees" -gt 1 ]; then
+        problems="$problems
+  $worktrees linked worktrees; a shared checkout must not be mutated by several jobs"
+    fi
+
+    if [ -z "$problems" ]; then
+        return 0
+    fi
+
+    if [ "${ASTRO_ALLOW_DIRTY_CHROMIUM:-0}" = "1" ] && [ "$VERIFY_ONLY" != "1" ]; then
+        astro::warn "override:dirty-chromium" \
+            "$name has local state, continuing because ASTRO_ALLOW_DIRTY_CHROMIUM=1:$problems"
+        return 0
+    fi
+
+    astro::die_with_hint \
+        "$name is not in a state this command may act on:$problems" \
+        "" \
+        "Astro preserves developer work by default, and a build must not start" \
+        "from a tree nobody can describe." \
+        "" \
+        "Recovery steps: docs/recovery.mdx" \
+        "Developer override: ASTRO_ALLOW_DIRTY_CHROMIUM=1 (never set in CI)"
+}
+
+# Reports the branch state a locked checkout must not be in. A branch can be
+# advanced after the sync; a detached HEAD at a recorded SHA cannot.
+report_head_state() {
+    local dir="$1" name="$2"
+    # symbolic-ref exits 1 on a detached HEAD, which is the desired state, so
+    # the status is captured rather than swallowed; anything above 1 is a real
+    # git failure and must not read as "detached".
+    local branch status=0
+    branch="$(git -C "$dir" symbolic-ref --quiet --short HEAD)" || status=$?
+    if [ "$status" -gt 1 ]; then
+        astro::die "could not read HEAD state of $dir (git exit $status)"
+    fi
+    if [ -n "$branch" ]; then
+        astro::warn "checkout-on-branch" \
+            "$name is on branch '$branch' rather than detached; it will be detached at the locked commit"
+    fi
+}
+
+# Astro's fetches are large enough that a transient network failure is a normal
+# event rather than an exceptional one. Each attempt is announced and the final
+# failure is fatal, so this is a retry, not a suppressed error.
+ASTRO_FETCH_ATTEMPTS="${ASTRO_FETCH_ATTEMPTS:-5}"
+
+# Depth of the initial fetch. Chromium's full history is tens of gigabytes over
+# a single connection, and a transient TLS reset loses ALL of it — git streams a
+# fetch into a temporary pack and discards it on failure, so a retry genuinely
+# starts over. Measured here: five consecutive attempts left .git at 120 KB.
+#
+# Fetching the locked ref at depth 1 transfers one commit's tree instead of the
+# whole history, which is a few gigabytes rather than tens, and is what makes
+# the difference between a bootstrap that completes and one that cannot. The
+# commit checked out is still exactly the one the lock names, so nothing about
+# reproducibility changes; only the local ancestry is absent.
+#
+# Set ASTRO_FETCH_DEPTH= (empty) for full history, which `git fetch --unshallow`
+# can also add later.
+ASTRO_FETCH_DEPTH="${ASTRO_FETCH_DEPTH-1}"
+
+# Partial-clone filter for the initial network fetch. `blob:none` transfers the
+# commit and its trees but no file contents, turning one multi-gigabyte transfer
+# that must survive intact into a small one plus many small on-demand batches
+# during checkout — each of which fails and retries independently.
+#
+# On a link that dropped four times inside the first 220 MB, that is the
+# difference between a bootstrap that completes and one that cannot. The commit
+# is still exactly the one the lock names.
+#
+# The cost is real and worth stating: a blobless checkout needs network access
+# during the build to fetch contents it has not seen. Set ASTRO_FETCH_FILTER=
+# (empty) for a complete local copy.
+ASTRO_FETCH_FILTER="${ASTRO_FETCH_FILTER-blob:none}"
+
+fetch_with_retry() {
+    local dir="$1" ref="$2" name="$3"
+    local attempt=1 status=0
+    local -a depth_args=()
+
+    # Depth applies only to a NETWORK fetch into a still-empty repository.
+    #
+    # It exists to bound a transfer that can fail halfway, so it is meaningless
+    # for a file:// origin — and actively wrong there: a local fixture has no
+    # history worth truncating, and a shallow copy of one silently loses the
+    # older commits a test needs to move between. Deepening an existing
+    # checkout is a different operation and is never done implicitly.
+    local origin_url
+    origin_url="$(git -C "$dir" remote get-url origin)"
+    if [ -n "$ASTRO_FETCH_DEPTH" ] \
+       && [ -z "$(git -C "$dir" rev-list -n1 --all)" ] \
+       && case "$origin_url" in http://*|https://*) true ;; *) false ;; esac
+    then
+        depth_args=(--depth "$ASTRO_FETCH_DEPTH")
+        astro::info "  $name: initial fetch limited to depth $ASTRO_FETCH_DEPTH"
+        if [ -n "$ASTRO_FETCH_FILTER" ]; then
+            depth_args+=(--filter="$ASTRO_FETCH_FILTER")
+            astro::info "  $name: partial clone filter $ASTRO_FETCH_FILTER (contents fetched on demand)"
+        fi
+    fi
+
+    while [ "$attempt" -le "$ASTRO_FETCH_ATTEMPTS" ]; do
+        astro::info "  $name: fetching (attempt $attempt/$ASTRO_FETCH_ATTEMPTS)"
+        status=0
+        if [ -n "$ref" ]; then
+            git -C "$dir" fetch "${depth_args[@]+"${depth_args[@]}"}" \
+                origin "+$ref:refs/astro-locked/$name" || status=$?
+        else
+            git -C "$dir" fetch "${depth_args[@]+"${depth_args[@]}"}" --tags origin || status=$?
+        fi
+        if [ "$status" -eq 0 ]; then
+            return 0
+        fi
+        # Deliberately NOT claiming the partial transfer was kept: git discards
+        # the temporary pack when a fetch fails, so each attempt starts over.
+        astro::warn "retry:fetch" "$name fetch failed (exit $status); retrying from the start"
+        attempt=$((attempt + 1))
+    done
+
+    astro::die_with_hint \
+        "$name: fetch failed $ASTRO_FETCH_ATTEMPTS time(s)." \
+        "" \
+        "A failed git fetch discards its partial transfer, so every attempt starts" \
+        "over — this is not a resumable operation." \
+        "" \
+        "If the connection is unreliable, reduce what has to arrive in one go:" \
+        "  ASTRO_FETCH_DEPTH=1   fetch only the locked commit (the default)" \
+        "  ASTRO_FETCH_ATTEMPTS  raise the retry count"
+}
+
+# Ensures <dir> is a git checkout of <url> sitting detached at <commit>.
+sync_repository() {
+    local dir="$1" url="$2" commit="$3" ref="$4" name="$5"
+
+    if [ ! -d "$dir/.git" ]; then
+        if [ "$VERIFY_ONLY" = "1" ]; then
+            astro::die_with_hint \
+                "$name is not present at $dir" \
+                "--verify-only never creates a checkout." \
+                "Run tools/sync-sources.sh without --verify-only to bootstrap it."
+        fi
+        # A directory that exists, is not a checkout, and is not empty is the
+        # shape this repository was actually found in: chromium/src held only
+        # the copied overlay (4.2 MB of chrome/) with no upstream tree and no
+        # .git of its own. `git clone` into it fails with "destination path
+        # already exists and is not an empty directory", which says nothing
+        # about what the directory is or what to do with it — and the obvious
+        # reflex, deleting it, can destroy work nobody has copied anywhere.
+        if [ -d "$dir" ] && [ -n "$(ls -A "$dir")" ]; then
+            local backup listing
+            # Captured whole, then sliced with sed. Piping find into head sends
+            # SIGPIPE up the pipeline once head has its ten lines, which
+            # pipefail turns into exit 141 — the same hazard that killed
+            # --verify-only against a real checkout. `sed -n '1,10p'` without
+            # `q` reads to EOF, so nothing upstream is ever signalled.
+            listing="$(find "$dir" -mindepth 1 -maxdepth 1 -printf '%f\n' | sort)"
+            backup="${dir%/}.pre-sync.$(git -C "$ASTRO_ROOT" rev-parse --short HEAD)"
+            astro::die_with_hint \
+                "$name cannot be created at $dir: the directory already exists, is not a git checkout, and is not empty." \
+                "" \
+                "Contents:" \
+                "$(printf '%s\n' "$listing" | sed -n '1,10s/^/  /p')" \
+                "" \
+                "Nothing is deleted automatically. This is the shape a half-populated" \
+                "Astro tree takes — for example a chromium/src holding only the copied" \
+                "overlay — and it may be the only copy of something." \
+                "" \
+                "Move it aside, then re-run:" \
+                "  mv $dir \\" \
+                "     $backup" \
+                "  tools/sync-sources.sh" \
+                "" \
+                "Once the sync succeeds and you have confirmed nothing was lost:" \
+                "  rm -rf $backup"
+        fi
+
+        if astro::dry_run; then
+            astro::plan "clone $url -> $dir"
+            astro::plan "checkout --detach $commit in $dir"
+            return 0
+        fi
+        # `git clone` cannot resume. A Chromium clone moves tens of gigabytes
+        # over a single connection, and one transient TLS reset — observed here
+        # as "GnuTLS recv error (-110)" partway through — throws all of it away.
+        # init + fetch is resumable: a retry continues against the objects
+        # already in the local repository.
+        astro::info "  $name: creating $dir"
+        mkdir -p "$dir"
+        git -C "$dir" init --quiet
+        git -C "$dir" remote add origin "$url"
+    fi
+
+    if [ ! -d "$dir/.git" ]; then
+        astro::die "$dir is not a git repository after initialisation"
+    fi
+
+    # A freshly initialised repository has no HEAD yet, so there is nothing to
+    # compare against and nothing to keep clean — go straight to fetch and
+    # checkout below.
+    local head="" head_status=0
+    head="$(git -C "$dir" rev-parse HEAD 2>/dev/null)" || head_status=$?   # astro-allow:suppressed-stderr an empty repository legitimately has no HEAD
+    if [ "$head_status" -ne 0 ]; then
+        head=""
+    fi
+
+    if [ -n "$head" ] && [ "$head" = "$commit" ]; then
+        # Right commit is not enough. A fresh clone lands on a BRANCH at the
+        # same commit, and a branch can be advanced afterwards — by a stray
+        # `git pull`, by another job, by gclient — with nothing noticing that
+        # the build stopped being pinned. Detached HEAD at a recorded SHA
+        # cannot move without an explicit checkout.
+        assert_checkout_is_clean_enough "$dir" "$name"
+
+        local branch status=0
+        branch="$(git -C "$dir" symbolic-ref --quiet --short HEAD)" || status=$?
+        if [ "$status" -gt 1 ]; then
+            astro::die "could not read HEAD state of $dir (git exit $status)"
+        fi
+
+        if [ -z "$branch" ]; then
+            astro::info "  $name: already at $commit (detached)"
+            return 0
+        fi
+
+        if [ "$VERIFY_ONLY" = "1" ]; then
+            astro::die_with_hint \
+                "$name is at the locked commit but on branch '$branch', not detached." \
+                "A branch can be advanced after the sync, so the checkout is not" \
+                "actually pinned. Run tools/sync-sources.sh to detach it."
+        fi
+        if astro::dry_run; then
+            astro::plan "detach $name at $commit (currently on branch $branch)"
+            return 0
+        fi
+        astro::info "  $name: at $commit, detaching from branch '$branch'"
+        git -C "$dir" checkout --quiet --detach "$commit"
+        return 0
+    fi
+
+    if [ "$VERIFY_ONLY" = "1" ]; then
+        astro::die_with_hint \
+            "$name is at the wrong commit." \
+            "  on disk: ${head:-<empty repository>}" \
+            "  locked:  $commit" \
+            "" \
+            "This is the check a stale self-hosted runner must not pass. Run" \
+            "tools/sync-sources.sh (without --verify-only) to correct it."
+    fi
+
+    if [ -n "$head" ]; then
+        assert_checkout_is_clean_enough "$dir" "$name"
+        report_head_state "$dir" "$name"
+    fi
+
+    if astro::dry_run; then
+        astro::plan "fetch $ref from $url in $dir"
+        astro::plan "checkout --detach $commit in $dir (currently $head)"
+        return 0
+    fi
+
+    # Fetch WITHOUT changing what is checked out. `git fetch` updates remote
+    # refs only; the working tree moves in the explicit checkout below.
+    fetch_with_retry "$dir" "$ref" "$name"
+
+    # --verify --quiet suppresses only git's own "not a valid object" note,
+    # natively, rather than redirecting stderr and hiding real failures too.
+    if ! git -C "$dir" rev-parse --verify --quiet "${commit}^{commit}" >/dev/null; then
+        astro::die_with_hint \
+            "$name: locked commit $commit does not exist after fetching from $url" \
+            "The lock records a commit the origin does not have. Either the lock is" \
+            "wrong, or the commit was removed upstream." \
+            "Nothing nearby is substituted: an approximate source is not a source."
+    fi
+
+    astro::info "  $name: checking out $commit (detached)"
+    git -C "$dir" checkout --quiet --detach "$commit"
+
+    local now
+    now="$(git -C "$dir" rev-parse HEAD)"
+    if [ "$now" != "$commit" ]; then
+        astro::die "$name: checkout did not land on $commit (HEAD is $now)"
+    fi
+}
+
+# --------------------------------------------------------------------------
+# depot_tools FIRST — it resolves every other revision
+# --------------------------------------------------------------------------
+
+astro::info ">>> depot_tools"
+sync_repository "$DEPOT_TOOLS_DIR" "$DEPOT_TOOLS_URL" "$DEPOT_TOOLS_COMMIT" "" "depot_tools"
+export PATH="$DEPOT_TOOLS_DIR:$PATH"
+
+# --------------------------------------------------------------------------
+# Chromium
+# --------------------------------------------------------------------------
+
+astro::info ">>> Chromium $CHROMIUM_VERSION"
+
+if [ -d "$CHROMIUM_SRC/.git" ]; then
+    # Reuse #4's destination verification: the path must be its own git work
+    # tree carrying Chromium's sentinels, so a directory holding only the
+    # overlay can never be mistaken for a checkout.
+    ASTRO_CHROMIUM_SRC="$CHROMIUM_SRC" astro::resolve_chromium_src "$CHROMIUM_SRC"
+fi
+
+sync_repository "$CHROMIUM_SRC" "$CHROMIUM_URL" "$CHROMIUM_COMMIT" "$CHROMIUM_REF" "chromium"
+
+# --------------------------------------------------------------------------
+# .gclient — written from committed configuration, never string-built per run
+# --------------------------------------------------------------------------
+
+astro::require_file "$GCLIENT_TEMPLATE" "gclient template"
+
+render_gclient() {
+    local target_os_literal=""
+    local target
+    for target in $TARGET_OS_LIST; do
+        case "$target" in
+            linux|win|android|mac) target_os_literal="$target_os_literal\"$target\", " ;;
+            *) astro::die "Unknown target_os '$target' (expected linux, win, android or mac)" ;;
+        esac
+    done
+    target_os_literal="${target_os_literal%, }"
+
+    python3 - "$GCLIENT_TEMPLATE" "$CHROMIUM_URL" "$target_os_literal" <<'PY'
+import sys
+template_path, url, target_os = sys.argv[1:4]
+with open(template_path, encoding="utf-8") as handle:
+    template = handle.read()
+sys.stdout.write(
+    template.replace("@CHROMIUM_URL@", url).replace("@TARGET_OS@", target_os)
+)
+PY
+}
+
+GCLIENT_PATH="$CHROMIUM_DIR/.gclient"
+# .gclient is rendered and verified even under --no-deps: it is committed
+# configuration, not DEPS execution, and a checkout whose .gclient does not
+# match the template is configured differently from what the repository says.
+if astro::dry_run || [ "$VERIFY_ONLY" = "1" ]; then
+    if [ -f "$GCLIENT_PATH" ] && [ "$(render_gclient)" = "$(cat "$GCLIENT_PATH")" ]; then
+        astro::info "  .gclient matches the committed template"
+    elif [ "$VERIFY_ONLY" = "1" ]; then
+        astro::die_with_hint \
+            ".gclient does not match the committed template" \
+            "Template: $GCLIENT_TEMPLATE" \
+            "On disk:  $GCLIENT_PATH" \
+            "Run tools/sync-sources.sh to regenerate it."
+    else
+        astro::plan "write $GCLIENT_PATH from $GCLIENT_TEMPLATE"
+    fi
+else
+    render_gclient > "$GCLIENT_PATH"
+    astro::info "  .gclient written from $GCLIENT_TEMPLATE (target_os: $TARGET_OS_LIST)"
+fi
+
+# --------------------------------------------------------------------------
+# DEPS
+# --------------------------------------------------------------------------
+
+if [ "$RUN_DEPS" = "0" ]; then
+    astro::warn "optional:skip-deps" "--no-deps given: DEPS were NOT synced, so this tree is not buildable"
+elif [ "$VERIFY_ONLY" = "1" ]; then
+    astro::info "  --verify-only: not running gclient sync"
+elif astro::dry_run; then
+    astro::plan "gclient sync --revision src@$CHROMIUM_COMMIT --with_branch_heads --with_tags -D"
+    astro::plan "gclient runhooks"
+else
+    astro::require_cmd gclient
+    astro::info ">>> gclient sync (anchored to src@$CHROMIUM_COMMIT)"
+    ( cd "$CHROMIUM_DIR" && gclient sync --revision "src@$CHROMIUM_COMMIT" \
+        --with_branch_heads --with_tags -D )
+
+    # gclient sync can move src; the locked commit is what must be built.
+    head_after="$(git -C "$CHROMIUM_SRC" rev-parse HEAD)"
+    if [ "$head_after" != "$CHROMIUM_COMMIT" ]; then
+        astro::die_with_hint \
+            "gclient sync moved the Chromium checkout off the locked commit." \
+            "  locked:  $CHROMIUM_COMMIT" \
+            "  on disk: $head_after"
+    fi
+
+    astro::info ">>> gclient runhooks"
+    ( cd "$CHROMIUM_DIR" && gclient runhooks )
+
+    # Record what DEPS actually resolved to. This is the input to provenance
+    # and the only way to notice a DEPS-level change between two syncs of the
+    # same Chromium commit.
+    report_dir="$(astro::report_dir)"
+    ( cd "$CHROMIUM_DIR" && gclient revinfo --output-json="$report_dir/deps-revinfo.json" )
+    astro::info "  DEPS revisions recorded: $report_dir/deps-revinfo.json"
+fi
+
+# --------------------------------------------------------------------------
+# ungoogled-chromium (legacy; removed with the patch system in #8)
+# --------------------------------------------------------------------------
+
+astro::info ">>> ungoogled-chromium (legacy)"
+sync_repository "$UNGOOGLED_DIR" "$UNGOOGLED_URL" "$UNGOOGLED_COMMIT" "$UNGOOGLED_REF" "ungoogled_chromium"
+
+# --------------------------------------------------------------------------
+# Final report — every selected revision, at completion as well as at startup
+# --------------------------------------------------------------------------
+
+printf '\n=== Source revisions ===\n'
+python3 "$LOCK" --revisions "$LOCK_FILE" | while IFS=$'\t' read -r name revision; do
+    printf '  %-26s %s\n' "$name" "$revision"
+done
+
+if ! astro::dry_run; then
+    printf -- '--- verified on disk ---\n'
+    printf '  %-26s %s\n' "depot_tools" "$(git -C "$DEPOT_TOOLS_DIR" rev-parse HEAD)"
+    printf '  %-26s %s\n' "chromium" "$(git -C "$CHROMIUM_SRC" rev-parse HEAD)"
+    printf '  %-26s %s\n' "ungoogled_chromium" "$(git -C "$UNGOOGLED_DIR" rev-parse HEAD)"
+fi
+printf '=== end ===\n\n'
+
+astro::info "=== Source sync complete ==="

--- a/tools/sync-ungoogled.sh
+++ b/tools/sync-ungoogled.sh
@@ -6,41 +6,41 @@ source "$ASTRO_ROOT/tools/lib/astro-common.sh"
 UNGOOGLED_DIR="$ASTRO_ROOT/.ungoogled-chromium"
 PATCHES_DIR="$ASTRO_ROOT/patches/ungoogled"
 
-# Match this to the Chromium version we're building against
-CHROMIUM_VERSION="${CHROMIUM_VERSION:-146.0.7680.177}"
-UNGOOGLED_BRANCH="master"
+# The ungoogled-chromium revision is selected by browser.lock.json, never by
+# searching for a tag that looks close enough.
+#
+# The previous implementation tried the exact tag, then `git tag -l
+# "$MAJOR.*" | tail -1`, then master with a printed warning and a ZERO exit —
+# so a version bump could silently build against a patch set written for a
+# different Chromium, and the only trace was a line of console output. That is
+# the "no exact-version lookup falls back to a merely similar version" rule in
+# epic #3, and it is now enforced by tools/sync-sources.sh, which checks out
+# the locked commit or fails.
 
-echo "=== Syncing ungoogled-chromium patches ==="
+astro::info "=== Syncing ungoogled-chromium patches ==="
 
-# Clone or update ungoogled-chromium
-if [ ! -d "$UNGOOGLED_DIR" ]; then
-    echo ">>> Cloning ungoogled-chromium..."
-    git clone https://github.com/ungoogled-software/ungoogled-chromium.git "$UNGOOGLED_DIR"
-else
-    echo ">>> Updating ungoogled-chromium..."
-    cd "$UNGOOGLED_DIR" && git fetch origin && git checkout "$UNGOOGLED_BRANCH" && git pull
+astro::require_file "$ASTRO_ROOT/browser.lock.json" "lock file"
+LOCKED_UNGOOGLED="$(python3 "$ASTRO_ROOT/tools/lib/lock.py" --get ungoogled_chromium.commit)"
+LOCKED_VERSION="$(python3 "$ASTRO_ROOT/tools/lib/lock.py" --get ungoogled_chromium.version)"
+
+if [ ! -d "$UNGOOGLED_DIR/.git" ]; then
+    astro::die_with_hint \
+        "ungoogled-chromium checkout not found at $UNGOOGLED_DIR" \
+        "Run tools/sync-sources.sh, which checks it out at the locked commit."
 fi
 
+CURRENT="$(git -C "$UNGOOGLED_DIR" rev-parse HEAD)"
+if [ "$CURRENT" != "$LOCKED_UNGOOGLED" ]; then
+    astro::die_with_hint \
+        "ungoogled-chromium is not at the locked commit." \
+        "  on disk: $CURRENT" \
+        "  locked:  $LOCKED_UNGOOGLED ($LOCKED_VERSION)" \
+        "" \
+        "Nothing nearby is substituted. Run tools/sync-sources.sh."
+fi
+
+astro::info ">>> Using ungoogled-chromium $LOCKED_VERSION ($LOCKED_UNGOOGLED)"
 cd "$UNGOOGLED_DIR"
-
-# Find the closest matching version tag
-echo ""
-echo ">>> Looking for patches matching Chromium $CHROMIUM_VERSION..."
-MAJOR_VERSION=$(echo "$CHROMIUM_VERSION" | cut -d. -f1)
-
-# Try exact tag first, then closest major version
-MATCHING_TAG=$(git tag -l "${CHROMIUM_VERSION}-*" | sort -V | tail -1)
-if [ -z "$MATCHING_TAG" ]; then
-    MATCHING_TAG=$(git tag -l "${MAJOR_VERSION}.*" | sort -V | tail -1)
-fi
-
-if [ -n "$MATCHING_TAG" ]; then
-    echo "  Found matching tag: $MATCHING_TAG"
-    git checkout "$MATCHING_TAG"
-else
-    echo "  No exact match found, using latest $UNGOOGLED_BRANCH"
-    echo "  WARNING: Patches may not apply cleanly to Chromium $CHROMIUM_VERSION"
-fi
 
 # Copy patches to our patches directory
 echo ""

--- a/tools/tests/cases/build-verifies-locked-revisions.sh
+++ b/tools/tests/cases/build-verifies-locked-revisions.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# tools/build.sh must verify the Chromium checkout against browser.lock.json
+# BEFORE it validates anything else and before it generates anything.
+#
+# This is the property that makes a stale self-hosted runner unable to ship a
+# binary built from a commit nobody declared. Without it the tree compiles
+# silently and the resulting binary claims to be something it is not — and
+# nothing in the artifact says otherwise, because provenance is generated from
+# the same drifted tree.
+#
+# build.sh's required INPUT checks — GN args, the two build gates, the build
+# tools, WebUI bundles, ad blocker filter lists, the overlay sync — are the
+# layer below and live in build-fails-closed-on-missing-inputs.sh. They are a
+# separate case because none of the machinery here exists there: no lock, no
+# script to enforce it, no schema to validate it against.
+#
+# Everything runs against synthetic fixtures under the harness temporary
+# directory. The real chromium/ checkout is never read and never written.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+tmp="$(harness::tmpdir)"
+
+# A commit that exists in no fixture, so the lock can name a revision the
+# checkout demonstrably is not on.
+ABSENT_COMMIT="0000000000000000000000000000000000000001"
+
+fake_root="$tmp/astro-root"
+chromium="$tmp/chromium-src"
+harness::make_locked_build_root "$fake_root" "$chromium"
+
+# One real sync renders .gclient from the committed template, which the
+# verify-only gate then checks. Without it the gate would fail on
+# configuration rather than on the revision this case is about — a refusal for
+# the wrong reason, which reads exactly like a refusal for the right one.
+harness::setup_run env ASTRO_CHROMIUM_SRC="$chromium" \
+    "$fake_root/tools/sync-sources.sh" \
+    --no-deps --lock "$fake_root/browser.lock.json" \
+    --chromium-src "$chromium" \
+    --depot-tools "$fake_root/depot_tools" \
+    --ungoogled "$fake_root/.ungoogled-chromium"
+
+before="$(harness::manifest "$chromium")"
+
+CHROMIUM_HEAD="$(git -C "$chromium" rev-parse HEAD)"
+
+# --- The gate runs, and passes, against the checkout the lock describes ------
+#
+# The control. Every refusal below is satisfied by a build.sh that refuses
+# unconditionally, and only a run that gets THROUGH the gate tells the two
+# apart.
+
+harness::run env ASTRO_CHROMIUM_SRC="$chromium" \
+    "$fake_root/tools/build.sh" Release linux --dry-run
+
+harness::assert_status 0 "dry run against the checkout the lock names"
+harness::assert_output_contains "Verifying source revisions" "the lock gate runs"
+harness::assert_output_contains "gn gen" "a satisfied gate lets the build proceed"
+harness::assert_output_lacks "gn was executed during a dry run" "dry run must not invoke gn"
+harness::assert_tree_unchanged "$chromium" "$before"
+
+# The gate must run BEFORE the input checks, not merely at some point: a build
+# that validated inputs first would spend its time on a tree it was going to
+# reject anyway, and — worse — would report an input problem as the reason a
+# drifted checkout failed.
+gate_line="$(grep -nF 'Verifying source revisions' "$RUN_STDOUT" "$RUN_STDERR" | head -1 | cut -d: -f2)"
+bundles_line="$(grep -nF 'Checking required WebUI bundles' "$RUN_STDOUT" "$RUN_STDERR" | head -1 | cut -d: -f2)"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 2))
+for line_number in "$gate_line" "$bundles_line"; do
+    case "$line_number" in
+        ''|*[!0-9]*)
+            harness::fail "could not locate both ordering lines (gate: '$gate_line', bundles: '$bundles_line')"
+            ;;
+    esac
+done
+if [ "$gate_line" -ge "$bundles_line" ]; then
+    harness::fail "the lock gate (line $gate_line) does not run before the input checks (line $bundles_line)"
+fi
+
+# --- A checkout off the locked revision stops the build ---------------------
+
+harness::write_build_lock "$fake_root" "$chromium" "$ABSENT_COMMIT"
+
+harness::run env ASTRO_CHROMIUM_SRC="$chromium" \
+    "$fake_root/tools/build.sh" Release linux --dry-run
+
+harness::assert_nonzero_status "build against a checkout off the locked revision"
+harness::assert_output_contains "wrong commit" "refusal reason"
+harness::assert_output_contains "$ABSENT_COMMIT" "the refusal names the commit the lock demanded"
+harness::assert_output_contains "$CHROMIUM_HEAD" "the refusal names the commit on disk"
+harness::assert_output_lacks "gn gen" "must fail before build generation"
+harness::assert_tree_unchanged "$chromium" "$before"
+
+# --- The override exists for bisecting upstream, and announces itself --------
+#
+# Being deliberately off-lock is the entire point of a bisect, so the override
+# is not a hole to be closed. What it must not be is silent: it prints a
+# structured warning, and the same drift lands in the provenance file.
+
+harness::run env ASTRO_CHROMIUM_SRC="$chromium" ASTRO_SKIP_LOCK_VERIFY=1 \
+    "$fake_root/tools/build.sh" Release linux --dry-run
+
+harness::assert_status 0 "explicit lock-verification override"
+harness::assert_output_contains "override:skip-lock-verify" "structured override warning"
+harness::assert_output_lacks "Verifying source revisions" "the override really skipped the gate"
+harness::assert_tree_unchanged "$chromium" "$before"
+
+harness::pass

--- a/tools/tests/cases/deps-verification.sh
+++ b/tools/tests/cases/deps-verification.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# A recorded `gclient revinfo` is only worth what checking it proves.
+#
+# tools/sync-sources.sh writes build/reports/deps-revinfo.json after every sync;
+# tools/verify-deps.sh is what turns that record into a verdict. This case
+# governs the verdict, so every fixture here is SYNTHETIC revinfo JSON written
+# by the test. The real chromium/ checkout is never read: a case that depends on
+# a 55 GB tree cannot run on a clean machine, and a case that would pass without
+# the tree being correct proves nothing anyway.
+#
+# The failures that matter are the quiet ones: a record whose Chromium commit
+# drifted from the lock, a dependency that moved while the Chromium commit
+# stayed put, and a record that is simply absent — which must never read as
+# "nothing to report".
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+VERIFY="$ASTRO_ROOT/tools/verify-deps.sh"
+tmp="$(harness::tmpdir)"
+
+harness::assert_file_exists "$VERIFY"
+
+# --- A lock for the fixtures to be checked against ---------------------------
+#
+# Nothing is fetched here — verify-deps.sh reads chromium.commit and no more —
+# but the lock still has to satisfy browser.lock.schema.json, so it is written
+# through the same helper every other source-lock case uses.
+
+LOCKED_SHA="1111111111111111111111111111111111111111"
+OTHER_SHA="2222222222222222222222222222222222222222"
+DEPOT_SHA="3333333333333333333333333333333333333333"
+UNGOOGLED_SHA="4444444444444444444444444444444444444444"
+SKIA_BEFORE="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+SKIA_AFTER="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+NESTED_SHA="cccccccccccccccccccccccccccccccccccccccc"
+
+lock="$tmp/browser.lock.json"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$tmp/browser.lock.schema.json"
+harness::write_lock "$lock" \
+    "file://$tmp/chromium" "$LOCKED_SHA" \
+    "file://$tmp/depot_tools" "$DEPOT_SHA" \
+    "file://$tmp/ungoogled" "$UNGOOGLED_SHA"
+
+# --- Fixtures ----------------------------------------------------------------
+
+# Writes a revinfo record in the shape `gclient revinfo --output-json` emits.
+#
+# The keys are written in DELIBERATELY jumbled order: the snapshot this tool
+# records must be sorted, and a fixture that is already sorted cannot tell a
+# sorting implementation from one that merely copies its input.
+write_revinfo() {
+    local path="$1" src_revision="$2" skia_revision="$3"
+    python3 - "$path" "$src_revision" "$skia_revision" "$NESTED_SHA" <<'PY'
+import json, sys
+
+path, src_revision, skia_revision, nested_revision = sys.argv[1:5]
+
+document = {
+    "src/third_party/skia": f"https://skia.googlesource.com/skia.git@{skia_revision}",
+    # A branch and a tag: both resolve to a different commit over time, which is
+    # the hole in the lock's guarantee this tool has to make visible.
+    "src/third_party/moving": "https://example.invalid/moving.git@refs/heads/main",
+    "src": f"https://chromium.googlesource.com/chromium/src.git@{src_revision}",
+    "src/third_party/tagged": "https://example.invalid/tagged.git@refs/tags/v1.2.3",
+    # No revision and no digest in the name: the record does not say how this is
+    # pinned, which is neither a pass nor a finding.
+    "src/third_party/norevision": "https://example.invalid/norevision.git",
+    # The nested-object shape, which some gclient versions emit.
+    "src/third_party/nested": {
+        "url": "https://example.invalid/nested.git",
+        "rev": nested_revision,
+    },
+}
+
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(document, handle, indent=2)
+    handle.write("\n")
+PY
+}
+
+# The four pin shapes a REAL `gclient revinfo` carries, transcribed from
+# build/reports/deps-revinfo.json (234 entries, Chromium fully synced). Three of
+# the four are not 40-hex and are nonetheless immutable — classifying on "is it
+# a SHA" called 75 of those 234 holes in the lock when the true number is 10.
+#
+# `managed: False` in tools/gclient.template means gclient does not select the
+# solution's revision, so the real record's `src` entry carries rev: null. That
+# is the designed state, and it must not read as a failure OR as a pass.
+write_real_shapes() {
+    local path="$1" solution_revision="$2" updater_revision="$3"
+    python3 - "$path" "$solution_revision" "$updater_revision" <<'PY'
+import json, sys
+
+path, solution_revision, updater_revision = sys.argv[1:4]
+
+document = {
+    # The solution. `null` when gclient did not select it; a string when it did.
+    "src": {
+        "url": "https://chromium.googlesource.com/chromium/src.git",
+        "rev": None if solution_revision == "null" else solution_revision,
+    },
+    # A plain git dependency: 159 of the real record's entries are this.
+    "src/net/third_party/quiche/src": {
+        "url": "https://quiche.googlesource.com/quiche.git",
+        "rev": "24430cb4103438f3cd1680f8f89d7c9e4288d5ca",
+    },
+    # A CIPD package pinned by a commit SHA wearing a tag prefix. Commit-pinned,
+    # not a moving ref.
+    "src/tools/luci-go:infra/tools/luci/cas/${platform}": {
+        "url": "https://chrome-infra-packages.appspot.com/infra/tools/luci/cas/${platform}",
+        "rev": "git_revision:072101cbfec3372b812ff510df8547d7b4187bea",
+    },
+    # A CIPD instance id: base64url content hash, ending in the algorithm byte.
+    # Stronger than a git SHA — it names the built artifact.
+    "src/third_party/updater/chrome_linux64_sans_iid/cipd:chromium/third_party/updater/chrome_linux64": {
+        "url": "https://chrome-infra-packages.appspot.com/chromium/third_party/updater/chrome_linux64",
+        "rev": updater_revision,
+    },
+    # A GCS object named after its own SHA-256. No revision field at all.
+    "src/third_party/test_fonts/test_fonts:a28b222b79851716f8358d2800157d9ffe117b3545031ae51f69b7e1e1b9a969": {
+        "url": "gs://chromium-fonts/a28b222b79851716f8358d2800157d9ffe117b3545031ae51f69b7e1e1b9a969",
+        "rev": None,
+    },
+    # A GCS object whose name embeds a 40-char git hash among other tokens.
+    "src/third_party/rust-toolchain": {
+        "url": "gs://chromium-browser-clang/Linux_x64/rust-toolchain-7d8ebe3128fc87f3da1ad64240e63ccf07b8f0bd-3-llvmorg-23-init-2224-g5bd8dadb.tar.xz",
+        "rev": None,
+    },
+    # A GCS object whose name carries only an ABBREVIATED hash (g5bd8dadb) and a
+    # build number. The record does not establish how it is pinned, and an
+    # 8-character hash must not be mistaken for a content address.
+    "src/third_party/llvm-build/Release+Asserts:Linux_x64/clang-llvmorg-23-init-2224-g5bd8dadb-3.tar.xz": {
+        "url": "gs://chromium-browser-clang/Linux_x64/clang-llvmorg-23-init-2224-g5bd8dadb-3.tar.xz",
+        "rev": None,
+    },
+    # A CIPD tag. THIS is the real hole: a tag is resolved at sync time and can
+    # be repointed at a different package instance.
+    "src/third_party/updater/chrome_linux64/cipd:chromium/third_party/updater/chrome_linux64": {
+        "url": "https://chrome-infra-packages.appspot.com/chromium/third_party/updater/chrome_linux64",
+        "rev": "version:2",
+    },
+}
+
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(document, handle, indent=2)
+    handle.write("\n")
+PY
+}
+
+matching="$tmp/matching.json"
+mismatched="$tmp/mismatched.json"
+moved="$tmp/moved.json"
+write_revinfo "$matching" "$LOCKED_SHA" "$SKIA_BEFORE"
+write_revinfo "$mismatched" "$OTHER_SHA" "$SKIA_BEFORE"
+write_revinfo "$moved" "$LOCKED_SHA" "$SKIA_AFTER"
+
+verify() {
+    harness::run "$VERIFY" --lock "$lock" "$@"
+}
+
+# --- A missing record must refuse, not report success ------------------------
+#
+# This is the fail-closed property. "No revinfo file" means nobody observed what
+# DEPS resolved to; reporting success would certify a claim no evidence was ever
+# produced for.
+
+absent="$tmp/never-written/deps-revinfo.json"
+unwritten="$tmp/must-not-be-written.tsv"
+
+verify --revinfo "$absent" --record "$unwritten"
+harness::assert_nonzero_status "a missing revinfo record"
+harness::assert_output_contains "$absent" "names the file it could not find"
+harness::assert_output_contains "tools/sync-sources.sh" "says how to produce one"
+# A refusal that still writes its output file has produced an artifact nobody
+# has evidence for.
+harness::assert_file_missing "$unwritten"
+
+# --- The Chromium commit is the point ----------------------------------------
+
+verify --revinfo "$matching"
+harness::assert_status 0 "a record whose src matches the lock"
+harness::assert_output_contains "$LOCKED_SHA" "names the verified commit"
+harness::assert_output_contains "VERIFIED" "states the verdict it reached"
+
+verify --revinfo "$mismatched"
+harness::assert_nonzero_status "a record whose src does not match the lock"
+harness::assert_output_contains "does not match the lock" "reason for the refusal"
+harness::assert_output_contains "$LOCKED_SHA" "prints the commit the lock records"
+harness::assert_output_contains "$OTHER_SHA" "prints the commit gclient resolved"
+harness::assert_output_lacks "VERIFIED" "a mismatch must not also read as verified"
+
+# --- A record with no `src` entry cannot yield a verdict ---------------------
+
+python3 - "$tmp/no-solution.json" <<'PY'
+import json, sys
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump({"src/third_party/skia": "https://example.invalid/skia.git@" + "a" * 40},
+              handle, indent=2)
+PY
+
+verify --revinfo "$tmp/no-solution.json"
+harness::assert_nonzero_status "a record with no src solution"
+harness::assert_output_contains "solution is absent" "reason for the refusal"
+harness::assert_output_contains "src/third_party/skia" "names what the record did hold"
+
+# --- The recorded snapshot is deterministic ----------------------------------
+#
+# A snapshot that is not byte-stable makes every diff between two syncs noise,
+# which is the same as having no diff at all.
+
+first="$tmp/snapshot-1.tsv"
+second="$tmp/snapshot-2.tsv"
+
+verify --revinfo "$matching" --record "$first"
+harness::assert_status 0 "first --record run"
+harness::assert_file_exists "$first"
+
+verify --revinfo "$matching" --record "$second"
+harness::assert_status 0 "second --record run"
+harness::assert_files_identical "$first" "$second"
+
+# Determinism must not depend on the key order of the input, which JSON does not
+# constrain and gclient does not promise.
+python3 - "$matching" "$tmp/reordered.json" <<'PY'
+import json, sys
+
+source, destination = sys.argv[1:3]
+with open(source, encoding="utf-8") as handle:
+    document = json.load(handle)
+with open(destination, "w", encoding="utf-8") as handle:
+    json.dump({key: document[key] for key in sorted(document, reverse=True)},
+              handle, indent=2)
+PY
+
+reordered="$tmp/snapshot-reordered.tsv"
+verify --revinfo "$tmp/reordered.json" --record "$reordered"
+harness::assert_status 0 "--record over a reordered input"
+harness::assert_files_identical "$first" "$reordered"
+
+# The snapshot is the diffable form, so its shape is part of the contract.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$first" "$LOCKED_SHA" <<'PY' || exit 1
+import sys
+
+path, locked = sys.argv[1:3]
+with open(path, encoding="utf-8") as handle:
+    lines = handle.read().splitlines()
+
+assert lines, "the snapshot is empty"
+paths = []
+for line in lines:
+    dependency, tab, value = line.partition("\t")
+    assert tab, f"line is not TAB-separated: {line!r}"
+    assert "@" in value, f"value is not url@revision: {value!r}"
+    paths.append(dependency)
+
+assert paths == sorted(paths), paths
+assert "src" in paths, paths
+assert any(line.endswith("@" + locked) for line in lines), lines
+PY
+
+# --- Moving refs are the finding; other pins are not -------------------------
+
+verify --revinfo "$matching"
+harness::assert_status 0 "summary run"
+harness::assert_output_contains "pinned to a moving ref (2)" "counts only what can move"
+harness::assert_output_contains "src/third_party/moving" "names the branch-pinned dependency"
+harness::assert_output_contains "refs/heads/main" "prints the branch it is pinned to"
+harness::assert_output_contains "src/third_party/tagged" "names the tag-pinned dependency"
+harness::assert_output_contains "refs/tags/v1.2.3" "prints the tag it is pinned to"
+# The nested-object form must normalise into a real commit pin rather than being
+# counted as a hole or dropped.
+harness::assert_output_contains "commit-pinned:           2" "counts commit pins, nested form included"
+# No revision and no digest: the record does not say, and saying so is neither a
+# pass nor a finding.
+harness::assert_output_contains "not classifiable from this record (1)" "counts what it cannot classify"
+harness::assert_output_contains "src/third_party/norevision" "names the entry with no revision"
+
+# --- The four pin shapes a real record actually carries ----------------------
+#
+# Three of the four are not 40-hex and are immutable anyway. Only the CIPD tag
+# may be reported, or this tool reports 75 findings against a correct checkout
+# and gets ignored within a week.
+
+real="$tmp/real-shapes.json"
+write_real_shapes "$real" "null" "ytJ0UbU9gMLUMLRQlmqQpGpOy1dYswI3rOJ0ILnIFbUC"
+
+verify --revinfo "$real"
+harness::assert_status 0 "a record in the shape a real gclient sync produces"
+
+harness::assert_output_contains "commit-pinned:           2" "counts both spellings of a commit pin"
+harness::assert_output_contains "content-addressed:       3" "counts CIPD instance ids and digest-named GCS objects"
+harness::assert_output_contains "moving-ref:              1" "counts only the CIPD tag"
+harness::assert_output_contains "unclassified:            1" "counts the object it cannot classify"
+
+# A commit SHA wearing a CIPD tag prefix is a commit pin, not a moving ref.
+harness::assert_output_lacks "git_revision:072101cbfec3372b812ff510df8547d7b4187bea" \
+    "git_revision: is a commit pin and must not be reported as a hole"
+# A CIPD instance id is a content address — stronger than a git SHA.
+harness::assert_output_lacks "ytJ0UbU9gMLUMLRQlmqQpGpOy1dYswI3rOJ0ILnIFbUC" \
+    "a CIPD instance id must not be reported as a hole"
+# A GCS object named after its own digest cannot be repointed.
+harness::assert_output_lacks "gs://chromium-fonts" \
+    "a digest-named GCS object must not be reported as a hole"
+
+# The one real hole is named, with the tag it is pinned to.
+harness::assert_output_contains "pinned to a moving ref (1)" "reports exactly one hole"
+harness::assert_output_contains "MOVING-REF" "reports it as a structured finding"
+harness::assert_output_contains "version:2" "prints the tag that can move"
+
+# An 8-character hash inside a build-numbered tarball name is not a content
+# address, and must not be counted as one.
+harness::assert_output_contains "clang-llvmorg-23-init-2224-g5bd8dadb-3.tar.xz" \
+    "names the object whose pin the record does not establish"
+
+# --- A solution with no revision is the designed state, not a fault ----------
+#
+# tools/gclient.template sets managed: False, so gclient does not select the
+# solution's revision — tools/sync-sources.sh does, and verifies HEAD against
+# the lock afterwards. Failing here would mean this tool can never pass on a
+# correct checkout; claiming a verification would be worse.
+
+harness::assert_output_contains "DEFERRED" "says the solution revision was not established here"
+harness::assert_output_contains "managed: False" "names why the record carries no solution revision"
+harness::assert_output_contains "tools/sync-sources.sh --verify-only" "points at the check that does establish it"
+harness::assert_output_contains "$LOCKED_SHA" "still prints the commit the lock records"
+harness::assert_output_lacks "VERIFIED" "a deferred check must never read as a verified one"
+
+# The solution being ABSENT is still a failure: "no entry" and "an entry with no
+# revision" are different facts and only one of them is designed.
+python3 - "$tmp/no-solution-real.json" <<'PY'
+import json, sys
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump({"src/net/third_party/quiche/src": {
+        "url": "https://quiche.googlesource.com/quiche.git", "rev": "a" * 40}},
+        handle, indent=2)
+PY
+verify --revinfo "$tmp/no-solution-real.json"
+harness::assert_nonzero_status "a record with no src entry at all"
+harness::assert_output_contains "solution is absent" "reason for the refusal"
+
+# --- The mismatch check is not weakened by any of the above ------------------
+
+write_real_shapes "$tmp/real-mismatch.json" "$OTHER_SHA" "ytJ0UbU9gMLUMLRQlmqQpGpOy1dYswI3rOJ0ILnIFbUC"
+verify --revinfo "$tmp/real-mismatch.json"
+harness::assert_nonzero_status "a recorded solution revision that disagrees with the lock"
+harness::assert_output_contains "does not match the lock" "reason for the refusal"
+harness::assert_output_contains "$LOCKED_SHA" "prints the commit the lock records"
+harness::assert_output_contains "$OTHER_SHA" "prints the commit the record carries"
+
+write_real_shapes "$tmp/real-match.json" "$LOCKED_SHA" "ytJ0UbU9gMLUMLRQlmqQpGpOy1dYswI3rOJ0ILnIFbUC"
+verify --revinfo "$tmp/real-match.json"
+harness::assert_status 0 "a recorded solution revision that agrees with the lock"
+harness::assert_output_contains "VERIFIED" "a recorded, matching revision IS verified here"
+
+# --- Only moving refs may gate ------------------------------------------------
+
+# A record whose only non-SHA pins are content-addressed must pass the gate.
+python3 - "$tmp/content-only.json" "$LOCKED_SHA" <<'PY'
+import json, sys
+
+path, solution_revision = sys.argv[1:3]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump({
+        "src": {"url": "https://chromium.googlesource.com/chromium/src.git",
+                "rev": solution_revision},
+        "src/third_party/updater/chrome_linux64_sans_iid/cipd:chromium/third_party/updater/chrome_linux64": {
+            "url": "https://chrome-infra-packages.appspot.com/chromium/third_party/updater/chrome_linux64",
+            "rev": "ytJ0UbU9gMLUMLRQlmqQpGpOy1dYswI3rOJ0ILnIFbUC"},
+        "src/third_party/test_fonts/test_fonts:a28b222b79851716f8358d2800157d9ffe117b3545031ae51f69b7e1e1b9a969": {
+            "url": "gs://chromium-fonts/a28b222b79851716f8358d2800157d9ffe117b3545031ae51f69b7e1e1b9a969",
+            "rev": None},
+        "src/tools/luci-go:infra/tools/luci/cas/${platform}": {
+            "url": "https://chrome-infra-packages.appspot.com/infra/tools/luci/cas/${platform}",
+            "rev": "git_revision:072101cbfec3372b812ff510df8547d7b4187bea"},
+    }, handle, indent=2)
+PY
+
+verify --revinfo "$tmp/content-only.json" --fail-on-moving-ref
+harness::assert_status 0 "--fail-on-moving-ref over content-addressed and commit pins only"
+harness::assert_output_contains "moving-ref:              0" "counts no holes"
+harness::assert_output_lacks "MOVING-REF" "nothing may be reported as a moving ref"
+
+# ...and the same gate must fire on a version:N tag.
+verify --revinfo "$real" --fail-on-moving-ref
+harness::assert_nonzero_status "--fail-on-moving-ref over a record containing a CIPD tag"
+harness::assert_output_contains "--fail-on-moving-ref" "reason for the refusal"
+harness::assert_output_contains "version:2" "names the tag that can move"
+
+# Off by default: upstream Chromium ships these and Astro cannot fix them, so a
+# default failure would fail every correct build.
+verify --revinfo "$real"
+harness::assert_status 0 "a moving ref alone does not fail the run by default"
+
+# --- Drift against a baseline ------------------------------------------------
+#
+# Same Chromium commit, moved dependency: the case no check that compares only
+# the Chromium commit can see.
+
+verify --revinfo "$moved" --baseline "$first"
+harness::assert_status 0 "drift is reported without --fail-on-drift"
+harness::assert_output_contains "CHANGED" "reports the change as a structured entry"
+harness::assert_output_contains "src/third_party/skia" "names the dependency that moved"
+harness::assert_output_contains "$SKIA_BEFORE" "prints the baseline revision"
+harness::assert_output_contains "$SKIA_AFTER" "prints the current revision"
+harness::assert_output_contains "same Chromium commit" "says why this drift is the interesting one"
+harness::assert_output_contains "VERIFIED" "drift alone is not a lock mismatch"
+
+verify --revinfo "$moved" --baseline "$first" --fail-on-drift
+harness::assert_nonzero_status "--fail-on-drift against a moved dependency"
+harness::assert_output_contains "--fail-on-drift" "reason for the refusal"
+harness::assert_output_contains "src/third_party/skia" "still names the dependency that moved"
+
+# A raw revinfo record is accepted as a baseline too: it is a thing a previous
+# sync legitimately left behind.
+verify --revinfo "$moved" --baseline "$matching"
+harness::assert_status 0 "a raw revinfo JSON used as the baseline"
+harness::assert_output_contains "src/third_party/skia" "diffs against a raw revinfo baseline"
+
+# --- ...and the other direction: nothing changed means nothing reported ------
+#
+# A differ that always reports is worthless, and indistinguishable from one that
+# works, unless this half is asserted too.
+
+verify --revinfo "$matching" --baseline "$first"
+harness::assert_status 0 "identical snapshots"
+harness::assert_output_contains "no dependency revisions differ" "says the comparison ran"
+harness::assert_output_lacks "CHANGED" "nothing moved, so nothing may be reported as changed"
+harness::assert_output_lacks "$SKIA_AFTER" "the revision that did not appear must not be named"
+
+verify --revinfo "$matching" --baseline "$first" --fail-on-drift
+harness::assert_status 0 "--fail-on-drift with no drift"
+
+# --- Unrecognised shapes fail with a reason, not a stack trace ---------------
+
+printf 'this is not json at all\n' > "$tmp/broken.json"
+verify --revinfo "$tmp/broken.json"
+harness::assert_nonzero_status "a record that is not JSON"
+harness::assert_output_contains "not valid JSON" "reason for the refusal"
+harness::assert_output_lacks "Traceback" "a stack trace is not an error message"
+
+printf '["src", "src/third_party/skia"]\n' > "$tmp/array.json"
+verify --revinfo "$tmp/array.json"
+harness::assert_nonzero_status "a record whose top level is an array"
+harness::assert_output_contains "unrecognised revinfo shape" "reason for the refusal"
+harness::assert_output_contains "top level is a list" "names the shape it found"
+harness::assert_output_lacks "Traceback" "a stack trace is not an error message"
+
+printf '{"src": 12345}\n' > "$tmp/number.json"
+verify --revinfo "$tmp/number.json"
+harness::assert_nonzero_status "a record whose entry is a number"
+harness::assert_output_contains "unrecognised revinfo entry" "reason for the refusal"
+harness::assert_output_contains "src" "names the offending entry"
+harness::assert_output_lacks "Traceback" "a stack trace is not an error message"
+
+printf '{"src": {"repo": "x", "sha": "y"}}\n' > "$tmp/odd-object.json"
+verify --revinfo "$tmp/odd-object.json"
+harness::assert_nonzero_status "a nested entry with unrecognised keys"
+harness::assert_output_contains "which field holds the revision" "reason for the refusal"
+harness::assert_output_lacks "Traceback" "a stack trace is not an error message"
+
+# A baseline in neither accepted form must say so rather than compare against
+# whatever it managed to parse.
+printf 'src https://example.invalid/src.git@%s\n' "$LOCKED_SHA" > "$tmp/bad-baseline.tsv"
+verify --revinfo "$matching" --baseline "$tmp/bad-baseline.tsv"
+harness::assert_nonzero_status "a baseline that is neither a snapshot nor revinfo JSON"
+harness::assert_output_contains "unrecognised baseline line" "reason for the refusal"
+
+# --- A dry run writes nothing ------------------------------------------------
+
+planned="$tmp/dry-run-snapshot.tsv"
+verify --revinfo "$matching" --record "$planned" --dry-run
+harness::assert_status 0 "dry run over a matching record"
+harness::assert_output_contains "PLAN" "the planned write is announced"
+harness::assert_output_contains "$planned" "the plan names the file it would write"
+harness::assert_file_missing "$planned"
+
+harness::pass

--- a/tools/tests/cases/dirty-overlay-is-recorded-and-refused.sh
+++ b/tools/tests/cases/dirty-overlay-is-recorded-and-refused.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# What the dirty-overlay override COSTS, once a build has used it.
+#
+# tools/sync-overlay.sh refuses an overlay that does not match the commit being
+# built, and ASTRO_ALLOW_DIRTY_OVERLAY=1 waves that refusal through. The
+# refusal and the override are the layer below and are asserted in
+# overlay-must-derive-from-head.sh. What is asserted here is everything that
+# happens afterwards, all of which is written and read by the provenance
+# generator — which does not exist at that layer, and is why this is a separate
+# case:
+#
+#   * the resulting build is recorded as not reproducible, machine-readably,
+#     with the offending paths NAMED rather than a bare verdict;
+#   * a committed overlay is recorded as clean, so the verdict is not simply
+#     this generator's only answer;
+#   * a MISSING manifest is recorded as "unmeasured", never as clean;
+#   * the strict verdict a release build asks for is refused;
+#   * normal packaging then refuses the artifact, and the deliberate override
+#     names the artifact for what it is.
+#
+# Everything runs against synthetic fixtures under the harness temporary
+# directory. The real chromium/ checkout and the real releases/ directory are
+# never touched.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+SYNC="$ASTRO_ROOT/tools/sync-overlay.sh"
+PROVENANCE="$ASTRO_ROOT/tools/generate-provenance.sh"
+
+tmp="$(harness::tmpdir)"
+chromium="$tmp/chromium-src"
+repo="$tmp/astro"
+overlay="$repo/src"
+allowlist="$tmp/overlay.allowlist"
+patches="$tmp/patches"
+mkdir -p "$patches"
+
+harness::make_chromium_fixture "$chromium"
+OVERLAY_HEAD="$(harness::make_overlay_repo "$repo" "$allowlist")"
+
+SERVICE_REL="chrome/browser/oxy/oxy_auth_service.cc"
+
+# --------------------------------------------------------------------------
+# The two manifests everything below is measured against
+#
+# Produced by really running the overlay sync rather than hand-written, so a
+# change to the manifest's shape surfaces here instead of leaving this case
+# asserting against a format nothing writes any more.
+# --------------------------------------------------------------------------
+
+sync_overlay() {
+    harness::setup_run env ASTRO_CHROMIUM_SRC="$chromium" "$@" "$SYNC" \
+        --source "$overlay" --dest "$chromium" --allowlist "$allowlist" \
+        --patches "$patches"
+}
+
+manifest="$ASTRO_REPORT_DIR/overlay-manifest.json"
+
+sync_overlay
+cp "$manifest" "$tmp/manifest-clean.json"
+
+printf '// LOCAL EDIT, never committed\n' > "$overlay/$SERVICE_REL"
+sync_overlay ASTRO_ALLOW_DIRTY_OVERLAY=1
+cp "$manifest" "$tmp/manifest-dirty.json"
+
+# The fixture floor. Every provenance assertion below is a statement about one
+# of these two manifests, so if the two are not actually a clean one and a dirty
+# one, the whole case is measuring a distinction that is not there — and a
+# refusal-heavy case fails to notice, because a broken fixture also produces
+# refusals.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$tmp/manifest-clean.json" "$tmp/manifest-dirty.json" "$OVERLAY_HEAD" "src/$SERVICE_REL" <<'PY' || exit 1
+import json, sys
+clean_path, dirty_path, head, changed = sys.argv[1:5]
+
+def state(path):
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)["source_state"]
+
+clean, dirty = state(clean_path), state(dirty_path)
+assert clean["state"] == "clean", clean
+assert clean["revision"] == head, clean
+assert dirty["state"] == "dirty", dirty
+assert dirty["override"] is True, dirty
+assert [entry["overlay_path"] for entry in dirty["differences"]] == [changed], dirty
+PY
+
+# --------------------------------------------------------------------------
+# Provenance records it, machine-readably
+# --------------------------------------------------------------------------
+
+mapfile -t DEPOT_SHAS < <(harness::make_source_repo "$tmp/depot_tools" depot_tools)
+mapfile -t UNGOOGLED_SHAS < <(harness::make_source_repo "$tmp/ungoogled" ungoogled)
+lock="$tmp/browser.lock.json"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$tmp/browser.lock.schema.json"
+harness::write_lock "$lock" \
+    "file://$chromium" "$(git -C "$chromium" rev-parse HEAD)" \
+    "file://$tmp/depot_tools" "${DEPOT_SHAS[2]}" \
+    "file://$tmp/ungoogled" "${UNGOOGLED_SHAS[2]}"
+
+generate_provenance() {
+    local overlay_manifest="$1" output="$2"
+    harness::run env ASTRO_CHROMIUM_SRC="$chromium" "$PROVENANCE" \
+        --lock "$lock" --output "$output" --platform linux --build-type Release \
+        --chromium-src "$chromium" --depot-tools "$tmp/depot_tools" \
+        --ungoogled "$tmp/ungoogled" --overlay-manifest "$overlay_manifest"
+}
+
+generate_provenance "$tmp/manifest-dirty.json" "$tmp/provenance-dirty.json"
+harness::assert_status 0 "provenance for a build made from a dirty overlay"
+harness::assert_output_contains "NOT-REPRODUCIBLE dirty overlay" "announced on stderr"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$tmp/provenance-dirty.json" "src/$SERVICE_REL" <<'PY' || exit 1
+import json, sys
+path, changed = sys.argv[1:3]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+
+assert document["reproducible"] is False, document["reproducible"]
+
+overlay = document["overlay"]
+assert overlay["state"] == "dirty", overlay
+assert overlay["clean"] is False, overlay
+assert overlay["override"] is True, overlay
+assert [entry["overlay_path"] for entry in overlay["differences"]] == [changed], overlay
+
+# The reason must NAME the paths: "not reproducible" with no subject is a
+# verdict nobody can act on.
+reasons = [line for line in document["not_reproducible_because"] if "overlay" in line]
+assert reasons, document["not_reproducible_because"]
+assert any(changed in line for line in reasons), reasons
+PY
+
+generate_provenance "$tmp/manifest-clean.json" "$tmp/provenance-clean.json"
+harness::assert_status 0 "provenance for a build made from a committed overlay"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$tmp/provenance-clean.json" "$OVERLAY_HEAD" <<'PY' || exit 1
+import json, sys
+path, head = sys.argv[1:3]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+
+overlay = document["overlay"]
+assert overlay["state"] == "clean", overlay
+assert overlay["clean"] is True, overlay
+assert overlay["revision"] == head, overlay
+
+# `reproducible` also answers for source drift and for worktrees this case does
+# not control, so the assertion is the one this case governs: no reason blames
+# the overlay. Without this, the dirty assertion above would pass just as well
+# against a generator that always blames the overlay.
+blamed = [line for line in document["not_reproducible_because"] if "overlay" in line]
+assert not blamed, blamed
+PY
+
+# A missing manifest is "unmeasured", never "clean": a check whose pass and
+# whose nothing-was-measured look the same certifies nothing.
+generate_provenance "$tmp/no-such-manifest.json" "$tmp/provenance-unmeasured.json"
+harness::assert_status 0 "provenance with no overlay manifest"
+harness::assert_output_contains "NOT-REPRODUCIBLE overlay unmeasured" "distinguishes it from clean"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$tmp/provenance-unmeasured.json" <<'PY' || exit 1
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    document = json.load(handle)
+overlay = document["overlay"]
+assert overlay["state"] == "unmeasured", overlay
+assert overlay["clean"] is False, overlay
+assert "sync-overlay.sh did not run" in (overlay["reason"] or ""), overlay
+assert document["reproducible"] is False, document["reproducible"]
+PY
+
+# A release build asks for the strict verdict, and must not get one.
+harness::run env ASTRO_CHROMIUM_SRC="$chromium" "$PROVENANCE" \
+    --lock "$lock" --output "$tmp/provenance-strict.json" \
+    --platform linux --build-type Release --require-match \
+    --chromium-src "$chromium" --depot-tools "$tmp/depot_tools" \
+    --ungoogled "$tmp/ungoogled" --overlay-manifest "$tmp/manifest-dirty.json"
+harness::assert_nonzero_status "--require-match against a dirty overlay"
+harness::assert_output_contains "did not come from a commit" "refusal names the overlay"
+
+# ==========================================================================
+# The verdict itself, with nothing else able to move it
+#
+# Every provenance run above executes the generator out of the REAL repository,
+# so `reproducible` there also answers for Astro's own worktree — which a test
+# cannot control and which is dirty whenever anyone is mid-change. Asserting
+# "reproducible is False" under those conditions passes whether or not the
+# overlay was consulted at all: mutation-testing confirmed it, a generator
+# computing the verdict as `not drift and not dirty` satisfied every assertion
+# above while ignoring the overlay entirely.
+#
+# So the verdict is measured once more where NOTHING ELSE is wrong: a
+# committed, clean miniature Astro repository holding the generator, a clean
+# Chromium fixture, and a lock naming exactly what is on disk. The overlay is
+# then the only input that can move the answer, in either direction.
+# ==========================================================================
+
+mirror="$tmp/astro-mirror"
+mkdir -p "$mirror/tools/lib"
+cp "$PROVENANCE" "$mirror/tools/"
+cp -R "$ASTRO_ROOT/tools/lib/." "$mirror/tools/lib/"
+# A byte-compiled cache copied out of the real tree would be COMMITTED here and
+# then rewritten by the first run — cp -R gives the sources new mtimes, so
+# python regenerates the .pyc — leaving this repository dirty for the second
+# run only. The control would then pass and the comparison fail, for a reason
+# that has nothing to do with the overlay.
+rm -rf "$mirror/tools/lib/__pycache__"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$mirror/"
+git -C "$mirror" init --quiet
+git -C "$mirror" add -A
+git -C "$mirror" commit --quiet -m "astro mirror: committed and clean"
+
+clean_chromium="$tmp/chromium-clean"
+harness::make_chromium_fixture "$clean_chromium"
+
+mirror_lock="$mirror/browser.lock.json"
+harness::write_lock "$mirror_lock" \
+    "file://$clean_chromium" "$(git -C "$clean_chromium" rev-parse HEAD)" \
+    "file://$tmp/depot_tools" "${DEPOT_SHAS[2]}" \
+    "file://$tmp/ungoogled" "${UNGOOGLED_SHAS[2]}"
+
+verdict_provenance() {
+    local overlay_manifest="$1" output="$2"
+    harness::run env ASTRO_CHROMIUM_SRC="$clean_chromium" \
+        "$mirror/tools/generate-provenance.sh" \
+        --lock "$mirror_lock" --output "$output" --platform linux --build-type Release \
+        --chromium-src "$clean_chromium" --depot-tools "$tmp/depot_tools" \
+        --ungoogled "$tmp/ungoogled" --overlay-manifest "$overlay_manifest"
+}
+
+verdict_provenance "$tmp/manifest-clean.json" "$tmp/verdict-clean.json"
+harness::assert_status 0 "verdict run with a committed overlay"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$tmp/verdict-clean.json" <<'PY' || exit 1
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    document = json.load(handle)
+# The control: with nothing else wrong, the answer is reproducible. Without
+# this, "not reproducible" could be this generator's only answer.
+assert document["drift"] == [], document["drift"]
+assert document["dirty_worktrees"] == [], document["dirty_worktrees"]
+assert document["not_reproducible_because"] == [], document["not_reproducible_because"]
+assert document["reproducible"] is True, document
+PY
+
+verdict_provenance "$tmp/manifest-dirty.json" "$tmp/verdict-dirty.json"
+harness::assert_status 0 "verdict run with an uncommitted overlay"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$tmp/verdict-dirty.json" "src/$SERVICE_REL" <<'PY' || exit 1
+import json, sys
+path, changed = sys.argv[1:3]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+# Same tree, same lock, same everything — only the overlay manifest differs.
+assert document["drift"] == [], document["drift"]
+assert document["dirty_worktrees"] == [], document["dirty_worktrees"]
+reasons = document["not_reproducible_because"]
+assert len(reasons) == 1, reasons
+assert reasons[0].startswith("dirty overlay"), reasons
+assert changed in reasons[0], reasons
+assert document["reproducible"] is False, document
+PY
+
+# ==========================================================================
+# Packaging refuses the result
+#
+# Run against a miniature Astro repository so the real releases/ directory is
+# never written to by a test.
+# ==========================================================================
+
+pkgroot="$tmp/pkgroot"
+mkdir -p "$pkgroot/tools/lib"
+cp "$ASTRO_ROOT/tools/package-release.sh" "$pkgroot/tools/"
+cp -R "$ASTRO_ROOT/tools/lib/." "$pkgroot/tools/lib/"
+printf '9.9.9-test\n' > "$pkgroot/VERSION"
+
+builddir="$tmp/out-release"
+mkdir -p "$builddir"
+# The markers tools/lib/overlay_in_binary.py looks for, so the binary check
+# passes and the overlay-provenance check is what this section measures.
+printf 'pad chrome://version pad chrome://alia pad astro-ntp pad astro-error pad' \
+    > "$builddir/chrome"
+printf 'sandbox\n' > "$builddir/chrome_sandbox"
+printf 'crashpad\n' > "$builddir/chrome_crashpad_handler"
+printf 'icu\n' > "$builddir/icudtl.dat"
+
+package() {
+    harness::run env "$@" "$pkgroot/tools/package-release.sh" "$builddir"
+}
+
+# --- a build from a committed overlay packages normally ----------------------
+cp "$tmp/provenance-clean.json" "$ASTRO_REPORT_DIR/provenance.json"
+package
+harness::assert_status 0 "packaging a build made from a committed overlay"
+harness::assert_file_exists "$pkgroot/releases/astro-9.9.9-test-linux-x64.tar.gz"
+
+# --- a build from a dirty overlay is refused ---------------------------------
+cp "$tmp/provenance-dirty.json" "$ASTRO_REPORT_DIR/provenance.json"
+package
+harness::assert_nonzero_status "packaging a build made from a dirty overlay"
+harness::assert_output_contains "Refusing to package a build whose overlay did not come from a commit" \
+    "refusal reason"
+harness::assert_output_contains "src/$SERVICE_REL" "names the offending overlay path"
+harness::assert_output_contains "ASTRO_ALLOW_DIRTY_OVERLAY_PACKAGE=1" "names the override"
+harness::assert_file_missing "$pkgroot/releases/unreproducible-9.9.9-test-linux-x64-DIRTY-OVERLAY.tar.gz"
+
+# --- and the override names the artifact for what it is ----------------------
+package ASTRO_ALLOW_DIRTY_OVERLAY_PACKAGE=1
+harness::assert_status 0 "packaging deliberately as an unreproducible artifact"
+harness::assert_output_contains "override:dirty-overlay-package" "structured override warning"
+harness::assert_file_exists "$pkgroot/releases/unreproducible-9.9.9-test-linux-x64-DIRTY-OVERLAY.tar.gz"
+
+# --- an unmeasured overlay is refused too, and differently -------------------
+cp "$tmp/provenance-unmeasured.json" "$ASTRO_REPORT_DIR/provenance.json"
+package ASTRO_ALLOW_DIRTY_OVERLAY_PACKAGE=1
+harness::assert_nonzero_status "packaging a build whose overlay state was never measured"
+harness::assert_output_contains "Cannot determine whether this build's overlay came from a commit" \
+    "refusal reason"
+harness::assert_output_lacks "Refusing to package a build whose overlay did not come" \
+    "must not report a verdict it does not have"
+
+harness::pass

--- a/tools/tests/cases/lock-failures-exit-non-zero.sh
+++ b/tools/tests/cases/lock-failures-exit-non-zero.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# "Every REQUIRED step that fails causes an immediate non-zero exit", applied
+# to the layer that declares source revisions rather than the one that builds
+# from them: tools/sync-sources.sh, browser.lock.json and the provenance
+# writer, plus build.sh's gate on the lock.
+#
+# The build pipeline's own required failures — the overlay sync, the patch
+# runner, build.sh's required inputs, the baseline capture tools — are the same
+# property one layer down and live in required-failures-exit-non-zero.sh. The
+# split is not cosmetic: none of the files this case exercises exist at that
+# layer, so a single table could not run there at all. The two tables share
+# their machinery (harness::register_failure / harness::run_failure_table)
+# rather than duplicating it, and each declares its own vacuity floor.
+#
+# Every row asserts WHY the command failed as well as that it did. A row
+# checking only "exit != 0" keeps passing once the script starts failing for
+# an unrelated reason — a fixture that was never built, a renamed flag, a typo
+# in an argument — and that is precisely how a suite goes green while the
+# guarantee underneath it is gone.
+#
+# Everything runs against synthetic fixtures under the harness temporary
+# directory. The real chromium/ checkout is never read and never written.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+tmp="$(harness::tmpdir)"
+TOOLS="$ASTRO_ROOT/tools"
+
+# A commit that exists in no fixture, used wherever a lock must name a
+# revision the checkout is not on.
+ABSENT_COMMIT="0000000000000000000000000000000000000001"
+
+# ==========================================================================
+# tools/sync-sources.sh
+# ==========================================================================
+
+sync_origins="$tmp/sync-origins"
+mkdir -p "$sync_origins"
+mapfile -t SYNC_CHROMIUM_SHAS < <(harness::make_source_repo "$sync_origins/chromium" chromium sentinels)
+mapfile -t SYNC_DEPOT_SHAS < <(harness::make_source_repo "$sync_origins/depot_tools" depot_tools)
+mapfile -t SYNC_UNGOOGLED_SHAS < <(harness::make_source_repo "$sync_origins/ungoogled" ungoogled)
+SYNC_CHROMIUM_TIP="${SYNC_CHROMIUM_SHAS[2]}"
+SYNC_CHROMIUM_OLD="${SYNC_CHROMIUM_SHAS[0]}"
+
+sync_lock_dir="$tmp/sync-lock"
+mkdir -p "$sync_lock_dir"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$sync_lock_dir/"
+sync_lock="$sync_lock_dir/browser.lock.json"
+harness::write_lock "$sync_lock" \
+    "file://$sync_origins/chromium" "$SYNC_CHROMIUM_TIP" \
+    "file://$sync_origins/depot_tools" "${SYNC_DEPOT_SHAS[2]}" \
+    "file://$sync_origins/ungoogled" "${SYNC_UNGOOGLED_SHAS[2]}"
+
+# Brings a fresh work tree to the locked revisions, so each row below starts
+# from a checkout that is correct and then breaks exactly one thing.
+bootstrap_work_tree() {
+    local work="$1"
+    mkdir -p "$work/chromium"
+    harness::setup_run env ASTRO_CHROMIUM_SRC="$work/chromium/src" "$TOOLS/sync-sources.sh" \
+        --no-deps --lock "$sync_lock" \
+        --chromium-src "$work/chromium/src" \
+        --depot-tools "$work/depot_tools" \
+        --ungoogled "$work/ungoogled"
+}
+
+# --- --verify-only against a wrong commit -----------------------------------
+
+sync_wrong="$tmp/sync-wrong"
+bootstrap_work_tree "$sync_wrong"
+harness::setup_run git -C "$sync_wrong/chromium/src" checkout --quiet --detach "$SYNC_CHROMIUM_OLD"
+
+run_sync_wrong_commit() {
+    env ASTRO_CHROMIUM_SRC="$sync_wrong/chromium/src" "$TOOLS/sync-sources.sh" \
+        --no-deps --verify-only --lock "$sync_lock" \
+        --chromium-src "$sync_wrong/chromium/src" \
+        --depot-tools "$sync_wrong/depot_tools" --ungoogled "$sync_wrong/ungoogled"
+}
+
+# --- --verify-only against an attached HEAD ---------------------------------
+#
+# The right commit is not enough: a branch can be advanced afterwards, and
+# nothing would notice that the build stopped being pinned.
+
+sync_branch="$tmp/sync-branch"
+bootstrap_work_tree "$sync_branch"
+harness::setup_run git -C "$sync_branch/chromium/src" checkout --quiet -b astro-146.0.7680.177
+
+run_sync_attached_head() {
+    env ASTRO_CHROMIUM_SRC="$sync_branch/chromium/src" "$TOOLS/sync-sources.sh" \
+        --no-deps --verify-only --lock "$sync_lock" \
+        --chromium-src "$sync_branch/chromium/src" \
+        --depot-tools "$sync_branch/depot_tools" --ungoogled "$sync_branch/ungoogled"
+}
+
+# --- --verify-only when the checkout is absent ------------------------------
+
+sync_absent="$tmp/sync-absent"
+bootstrap_work_tree "$sync_absent"
+rm -rf "${sync_absent:?}/chromium/src"
+
+run_sync_absent_checkout() {
+    env ASTRO_CHROMIUM_SRC="$sync_absent/chromium/src" "$TOOLS/sync-sources.sh" \
+        --no-deps --verify-only --lock "$sync_lock" \
+        --chromium-src "$sync_absent/chromium/src" \
+        --depot-tools "$sync_absent/depot_tools" --ungoogled "$sync_absent/ungoogled"
+}
+
+# --- A lock that fails schema validation ------------------------------------
+#
+# An abbreviated SHA is the most plausible mistake and the most dangerous: it
+# is not a syntax error, and abbreviations stop being unique as a repository
+# grows. The lock is validated before anything else looks at it, so no
+# checkout has to exist for this row.
+
+sync_bad_lock_dir="$tmp/sync-bad-lock"
+mkdir -p "$sync_bad_lock_dir"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$sync_bad_lock_dir/"
+sync_bad_lock="$sync_bad_lock_dir/browser.lock.json"
+harness::write_lock "$sync_bad_lock" \
+    "file://$sync_origins/chromium" "$SYNC_CHROMIUM_TIP" \
+    "file://$sync_origins/depot_tools" "${SYNC_DEPOT_SHAS[2]}" \
+    "file://$sync_origins/ungoogled" "${SYNC_UNGOOGLED_SHAS[2]}"
+harness::setup_run python3 - "$sync_bad_lock" <<'PY'
+import json, sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+document["chromium"]["commit"] = document["chromium"]["commit"][:7]
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(document, handle, indent=2)
+    handle.write("\n")
+PY
+
+run_sync_invalid_lock() {
+    env ASTRO_CHROMIUM_SRC="$tmp/sync-bad-lock-work/chromium/src" "$TOOLS/sync-sources.sh" \
+        --no-deps --verify-only --lock "$sync_bad_lock" \
+        --chromium-src "$tmp/sync-bad-lock-work/chromium/src" \
+        --depot-tools "$tmp/sync-bad-lock-work/depot_tools" \
+        --ungoogled "$tmp/sync-bad-lock-work/ungoogled"
+}
+
+# --- A non-empty, non-checkout directory at the destination -----------------
+#
+# The shape this repository was actually found in: chromium/src held only the
+# copied overlay. `git clone` into it fails with a message about the directory
+# already existing, and the obvious reflex — deleting it — can destroy the only
+# copy of something.
+
+sync_occupied="$tmp/sync-occupied"
+mkdir -p "$sync_occupied/chromium/src/chrome/browser/oxy"
+printf '// the copied overlay, and nothing else\n' \
+    > "$sync_occupied/chromium/src/chrome/browser/oxy/oxy_auth_service.cc"
+
+run_sync_occupied_destination() {
+    env ASTRO_CHROMIUM_SRC="$sync_occupied/chromium/src" "$TOOLS/sync-sources.sh" \
+        --no-deps --lock "$sync_lock" \
+        --chromium-src "$sync_occupied/chromium/src" \
+        --depot-tools "$sync_occupied/depot_tools" --ungoogled "$sync_occupied/ungoogled"
+}
+
+# ==========================================================================
+# tools/build.sh — the revision gate
+#
+# harness::make_locked_build_root supplies the fixture: everything a --dry-run
+# requires, plus the gate's own inputs — the script that enforces it, the
+# schema it is validated against, the provenance writer the same fixture would
+# run on a real build, and the depot_tools/ungoogled checkouts --verify-only
+# inspects. build-verifies-locked-revisions.sh, which asserts the gate's
+# ordering and its override in depth, builds on the same fixture; this row
+# exists so the gate also appears in the one table that enumerates every
+# required failure of this layer.
+# ==========================================================================
+
+# --- Checkout off the locked revision ---------------------------------------
+
+build_lock_root="$tmp/build-lock-root"
+build_lock_chromium="$tmp/build-lock-chromium"
+harness::make_locked_build_root "$build_lock_root" "$build_lock_chromium"
+harness::write_build_lock "$build_lock_root" "$build_lock_chromium" "$ABSENT_COMMIT"
+
+run_build_off_locked_revision() {
+    env ASTRO_CHROMIUM_SRC="$build_lock_chromium" \
+        "$build_lock_root/tools/build.sh" Release linux --dry-run
+}
+
+# ==========================================================================
+# tools/generate-provenance.sh --require-match
+# ==========================================================================
+
+provenance_drift="$tmp/provenance-drift"
+bootstrap_work_tree "$provenance_drift"
+harness::setup_run git -C "$provenance_drift/chromium/src" checkout --quiet --detach "$SYNC_CHROMIUM_OLD"
+
+run_provenance_drifted_revision() {
+    env ASTRO_CHROMIUM_SRC="$provenance_drift/chromium/src" "$TOOLS/generate-provenance.sh" \
+        --lock "$sync_lock" --output "$tmp/provenance-drift.json" \
+        --platform linux --build-type Release --require-match \
+        --chromium-src "$provenance_drift/chromium/src" \
+        --depot-tools "$provenance_drift/depot_tools" \
+        --ungoogled "$provenance_drift/ungoogled"
+}
+
+provenance_dirty="$tmp/provenance-dirty"
+bootstrap_work_tree "$provenance_dirty"
+printf 'local edit\n' >> "$provenance_dirty/chromium/src/content.txt"
+
+run_provenance_dirty_worktree() {
+    env ASTRO_CHROMIUM_SRC="$provenance_dirty/chromium/src" "$TOOLS/generate-provenance.sh" \
+        --lock "$sync_lock" --output "$tmp/provenance-dirty.json" \
+        --platform linux --build-type Release --require-match \
+        --chromium-src "$provenance_dirty/chromium/src" \
+        --depot-tools "$provenance_dirty/depot_tools" \
+        --ungoogled "$provenance_dirty/ungoogled"
+}
+
+# ==========================================================================
+# THE TABLE
+#
+# One line per required failure. Every entry names the reason the command must
+# give, so the row cannot be satisfied by an unrelated failure.
+# ==========================================================================
+
+harness::register_failure "--verify-only against a wrong commit" \
+    run_sync_wrong_commit \
+    "chromium is at the wrong commit" "$SYNC_CHROMIUM_OLD" "$SYNC_CHROMIUM_TIP" \
+    "stale self-hosted runner"
+harness::register_failure "--verify-only against an attached HEAD" \
+    run_sync_attached_head \
+    "not detached" "astro-146.0.7680.177" "can be advanced after the sync"
+harness::register_failure "--verify-only when the checkout is absent" \
+    run_sync_absent_checkout \
+    "chromium is not present at" "--verify-only never creates a checkout"
+harness::register_failure "a lock that fails schema validation" \
+    run_sync_invalid_lock \
+    "does not satisfy browser.lock.schema.json" "abbreviated SHA"
+harness::register_failure "a non-empty non-checkout directory at the destination" \
+    run_sync_occupied_destination \
+    "is not a git checkout, and is not empty" "Nothing is deleted automatically"
+
+harness::register_failure "build against a checkout off the locked revision" \
+    run_build_off_locked_revision \
+    "chromium is at the wrong commit" "$ABSENT_COMMIT"
+
+# The obvious fragment — "does not correspond to the lock" — is deliberately
+# NOT used here. generate-provenance.sh emits its refusal from a python3
+# heredoc, so when that program exits non-zero the ERR trap echoes the failing
+# command, and the failing command is the program TEXT, which contains the
+# refusal sentence as a string literal. The fragment therefore matches on any
+# non-zero exit of that block, including a python crash that never reached the
+# check. Only the runtime-formatted lines below distinguish the intended
+# refusal from an unrelated failure.
+harness::register_failure "provenance --require-match against a drifted revision" \
+    run_provenance_drifted_revision \
+    "DRIFT chromium: locked $SYNC_CHROMIUM_TIP, on disk $SYNC_CHROMIUM_OLD" \
+    "command failed (exit 1)"
+harness::register_failure "provenance --require-match against a dirty worktree" \
+    run_provenance_dirty_worktree \
+    "DIRTY chromium has uncommitted changes" "command failed (exit 1)"
+
+# ==========================================================================
+# Every required failure exits non-zero, and says why
+#
+# The floor is this case's own: 8 rows are registered above, and a truncated
+# table, a mis-registered row or a broken loop would otherwise report a green
+# case having asserted almost nothing.
+# ==========================================================================
+
+harness::run_failure_table 8
+
+# ==========================================================================
+# The fixtures were not vacuous either
+#
+# Every row above asserts a REFUSAL, and a refusal is exactly what a broken
+# fixture also produces. Two facts separate the two, and neither is implied by
+# any row: the lock the rows are pinned against names the tip commit the
+# fixture repositories were actually built at, and bootstrap_work_tree really
+# did place a checkout at that commit rather than leaving an empty directory
+# that every later command would refuse for the wrong reason.
+# ==========================================================================
+
+harness::assert_file_exists "$sync_lock"
+
+lock_chromium_commit="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["chromium"]["commit"])' "$sync_lock")"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ "$lock_chromium_commit" != "$SYNC_CHROMIUM_TIP" ]; then
+    harness::fail "the lock names $lock_chromium_commit, not the fixture tip $SYNC_CHROMIUM_TIP; every row above refused against a lock nobody built"
+fi
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ "$SYNC_CHROMIUM_OLD" = "$SYNC_CHROMIUM_TIP" ]; then
+    harness::fail "the fixture's first and last commits are identical, so the drift rows above cannot distinguish a pinned checkout from a drifted one"
+fi
+
+sync_control="$tmp/sync-control"
+bootstrap_work_tree "$sync_control"
+harness::run env ASTRO_CHROMIUM_SRC="$sync_control/chromium/src" "$TOOLS/sync-sources.sh" \
+    --no-deps --verify-only --lock "$sync_lock" \
+    --chromium-src "$sync_control/chromium/src" \
+    --depot-tools "$sync_control/depot_tools" --ungoogled "$sync_control/ungoogled"
+harness::assert_status 0 "control: --verify-only against the checkout the lock describes"
+
+harness::pass

--- a/tools/tests/cases/lock-schema-validation.sh
+++ b/tools/tests/cases/lock-schema-validation.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# The lock declares what gets compiled. A malformed one must be rejected with
+# the reason named, not partially acted on.
+#
+# The rejections that matter most are the ones that still "look like" a
+# revision: an abbreviated SHA, a branch name, a tag name. All three resolve to
+# different commits over time, which is the entire failure the lock exists to
+# prevent, and none of them is a syntax error.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+LOCK="$ASTRO_ROOT/tools/lib/lock.py"
+SCHEMA="$ASTRO_ROOT/browser.lock.schema.json"
+tmp="$(harness::tmpdir)"
+
+harness::assert_file_exists "$LOCK"
+harness::assert_file_exists "$SCHEMA"
+harness::assert_file_exists "$ASTRO_ROOT/browser.lock.json"
+
+# --- The repository's own lock is valid --------------------------------------
+
+harness::run python3 "$LOCK" --validate "$ASTRO_ROOT/browser.lock.json" "$SCHEMA"
+harness::assert_status 0 "the repository's browser.lock.json"
+harness::assert_output_contains "chromium" "revision listing"
+harness::assert_output_contains "depot_tools" "depot_tools is pinned"
+
+# Production origins must be https. The schema permits file:// so the fixtures
+# below can use real local git remotes without network; that relaxation must
+# not leak into the real lock.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if grep -q '"url": *"file://' "$ASTRO_ROOT/browser.lock.json"; then
+    harness::fail "browser.lock.json uses a file:// origin; production must be https"
+fi
+
+# Every recorded commit is a full 40-character lowercase SHA.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+while IFS=$'\t' read -r name revision; do
+    [ "$revision" = "UNPINNED" ] && continue
+    if ! printf '%s' "$revision" | grep -qE '^[0-9a-f]{40}$'; then
+        harness::fail "$name records '$revision', which is not a full 40-char SHA"
+    fi
+done < <(python3 "$LOCK" --revisions "$ASTRO_ROOT/browser.lock.json" "$SCHEMA")
+
+# --- Rejections --------------------------------------------------------------
+
+VALID_SHA="ae03f7fb2cf1215853896d6a4c15fdceee2badb7"
+DEPOT_SHA="41c40cfaec7ee3bf0423c59925d8b23982a601f1"
+
+write_lock_with() {
+    local path="$1" chromium_commit="$2"
+    python3 - "$path" "$chromium_commit" "$DEPOT_SHA" <<'PY'
+import json, sys
+path, chromium_commit, depot_commit = sys.argv[1:4]
+document = {
+    "lockfile_version": 1,
+    "chromium": {
+        "version": "146.0.7680.177",
+        "commit": chromium_commit,
+        "url": "https://chromium.googlesource.com/chromium/src.git",
+    },
+    "depot_tools": {
+        "commit": depot_commit,
+        "url": "https://chromium.googlesource.com/chromium/tools/depot_tools.git",
+    },
+}
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(document, handle, indent=2)
+PY
+}
+
+assert_rejected() {
+    local label="$1" path="$2" needle="$3"
+    harness::run python3 "$LOCK" --validate "$path" "$SCHEMA"
+    harness::assert_nonzero_status "$label"
+    harness::assert_output_contains "$needle" "reason for $label"
+}
+
+# An abbreviated SHA is the most plausible mistake, and the most dangerous:
+# abbreviations are not stable as a repository grows.
+write_lock_with "$tmp/abbrev.json" "ae03f7f"
+assert_rejected "abbreviated SHA" "$tmp/abbrev.json" "abbreviated SHA"
+
+write_lock_with "$tmp/branch.json" "main"
+assert_rejected "branch name" "$tmp/branch.json" "branch or tag name"
+
+write_lock_with "$tmp/tag.json" "refs/tags/146.0.7680.177"
+assert_rejected "tag name" "$tmp/tag.json" "branch or tag name"
+
+write_lock_with "$tmp/upper.json" "AE03F7FB2CF1215853896D6A4C15FDCEEE2BADB7"
+assert_rejected "uppercase SHA" "$tmp/upper.json" "lowercase"
+
+# Structural rejections.
+printf '{"lockfile_version": 1}\n' > "$tmp/missing.json"
+assert_rejected "missing chromium section" "$tmp/missing.json" "missing required field 'chromium'"
+
+python3 - "$tmp/version.json" "$VALID_SHA" "$DEPOT_SHA" <<'PY'
+import json, sys
+path, sha, depot = sys.argv[1:4]
+json.dump({
+    "lockfile_version": 2,
+    "chromium": {"version": "146.0.7680.177", "commit": sha,
+                 "url": "https://example.invalid/src.git"},
+    "depot_tools": {"commit": depot, "url": "https://example.invalid/dt.git"},
+}, open(path, "w", encoding="utf-8"))
+PY
+assert_rejected "unknown lockfile version" "$tmp/version.json" "expected 1"
+
+python3 - "$tmp/extra.json" "$VALID_SHA" "$DEPOT_SHA" <<'PY'
+import json, sys
+path, sha, depot = sys.argv[1:4]
+json.dump({
+    "lockfile_version": 1,
+    "chromium": {"version": "146.0.7680.177", "commit": sha,
+                 "url": "https://example.invalid/src.git", "typo_field": "x"},
+    "depot_tools": {"commit": depot, "url": "https://example.invalid/dt.git"},
+}, open(path, "w", encoding="utf-8"))
+PY
+assert_rejected "unexpected field" "$tmp/extra.json" "unexpected field"
+
+printf 'not json at all\n' > "$tmp/broken.json"
+assert_rejected "malformed JSON" "$tmp/broken.json" "not valid JSON"
+
+# An unpinned third-party entry must say WHY, or it is just a missing pin
+# wearing a declaration.
+python3 - "$tmp/no-reason.json" "$VALID_SHA" "$DEPOT_SHA" <<'PY'
+import json, sys
+path, sha, depot = sys.argv[1:4]
+json.dump({
+    "lockfile_version": 1,
+    "chromium": {"version": "146.0.7680.177", "commit": sha,
+                 "url": "https://example.invalid/src.git"},
+    "depot_tools": {"commit": depot, "url": "https://example.invalid/dt.git"},
+    "third_party": {"adblock_rust": {"pinned": False, "reason": ""}},
+}, open(path, "w", encoding="utf-8"))
+PY
+assert_rejected "unpinned entry with an empty reason" "$tmp/no-reason.json" "at least 1 character"
+
+# --- The validator must not silently skip a constraint it cannot enforce -----
+#
+# A partial validator that ignores unknown schema keywords looks enforced and
+# is not. This proves it refuses instead.
+
+python3 - "$tmp/odd-schema.json" "$SCHEMA" <<'PY'
+import json, sys
+out, schema_path = sys.argv[1:3]
+with open(schema_path, encoding="utf-8") as handle:
+    schema = json.load(handle)
+schema["properties"]["chromium"]["properties"]["commit"] = {"multipleOf": 3}
+with open(out, "w", encoding="utf-8") as handle:
+    json.dump(schema, handle)
+PY
+
+harness::run python3 "$LOCK" --validate "$ASTRO_ROOT/browser.lock.json" "$tmp/odd-schema.json"
+harness::assert_nonzero_status "schema keyword the validator does not implement"
+harness::assert_output_contains "does not implement" "refusal reason"
+harness::assert_output_contains "skipped constraint" "explains why it refuses"
+
+harness::pass

--- a/tools/tests/cases/no-banned-shell-patterns.sh
+++ b/tools/tests/cases/no-banned-shell-patterns.sh
@@ -17,10 +17,15 @@ harness::assert_file_exists "$SCANNER"
 
 # --- The real tree is clean --------------------------------------------------
 
+# CI workflow files are scanned too: `git pull` for a build dependency and
+# "skip synchronisation because .git exists" are ways a build stops being
+# pinned, and both lived in .github/workflows/release.yml.
 # shellcheck disable=SC2046  # deliberate word splitting over the file list
-harness::run python3 "$SCANNER" $(printf '%s\n' "$ASTRO_ROOT"/tools/*.sh "$ASTRO_ROOT"/tools/lib/*.sh)
+harness::run python3 "$SCANNER" $(printf '%s\n' \
+    "$ASTRO_ROOT"/tools/*.sh "$ASTRO_ROOT"/tools/lib/*.sh \
+    "$ASTRO_ROOT"/.github/workflows/*.yml)
 
-harness::assert_status 0 "scan of tools/*.sh"
+harness::assert_status 0 "scan of tools/*.sh and .github/workflows/*.yml"
 harness::assert_output_contains "no banned patterns" "clean result"
 
 # A vacuity floor: the scan must actually have read a meaningful number of
@@ -51,14 +56,13 @@ while IFS= read -r tracked_path; do
     mkdir -p "$committed/$(dirname "$tracked_path")"
     git -C "$ASTRO_ROOT" show "HEAD:$tracked_path" > "$committed/$tracked_path"
     tracked=$((tracked + 1))
-    # A git pathspec's `*` matches `/` too, so 'tools/*.sh' would sweep in
-    # tools/tests/**; the production scripts are tools/*.sh and tools/lib/*.sh
-    # only. The test suite is scanned separately and deliberately differently:
-    # patch-rejects-fuzz-and-3way.sh runs the banned constructs itself, to
-    # prove they would have applied the patch before asserting the runner
-    # refuses.
-done < <(git -C "$ASTRO_ROOT" ls-files 'tools/*.sh' \
-             | grep -E '^tools/(lib/)?[^/]+\.sh$')
+# A git pathspec's `*` matches `/` too, so 'tools/*.sh' would sweep in
+# tools/tests/**; the production scripts are tools/*.sh and tools/lib/*.sh
+# only. The test suite is scanned separately and deliberately differently:
+# patch-rejects-fuzz-and-3way.sh runs the banned constructs itself, to prove
+# they would have applied the patch before asserting the runner refuses.
+done < <(git -C "$ASTRO_ROOT" ls-files 'tools/*.sh' '.github/workflows/*.yml' \
+             | grep -E '^(tools/(lib/)?[^/]+\.sh|\.github/workflows/[^/]+\.ya?ml)$')
 
 HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
 if [ "$tracked" -lt 15 ]; then
@@ -66,8 +70,8 @@ if [ "$tracked" -lt 15 ]; then
 fi
 
 # shellcheck disable=SC2046  # deliberate word splitting over the file list
-harness::run python3 "$SCANNER" $(find "$committed" -name '*.sh' | sort)
-harness::assert_status 0 "scan of the COMMITTED tools/*.sh"
+harness::run python3 "$SCANNER" $(find "$committed" \( -name '*.sh' -o -name '*.yml' \) | sort)
+harness::assert_status 0 "scan of the COMMITTED tools/*.sh and workflows"
 
 # --- An empty invocation must not read as a pass -----------------------------
 
@@ -102,7 +106,38 @@ assert_rule_fires() {
     assert_rule_fires "fuzzy-patch"        'patch -p1 --forward -F3 < "$patch"'
     assert_rule_fires "suppressed-failure" 'cp "$a" "$b" || true'
     assert_rule_fires "suppressed-stderr"  'ninja -C out/Release chrome 2>/dev/null'
+    assert_rule_fires "unconstrained-pull" 'cd depot_tools && git pull'
 }
+
+# cache-as-source-of-truth is a workflow-only rule: a bootstrapping script may
+# test whether a checkout exists, a CI job may not decide for itself whether to
+# synchronise. Probe it with a workflow file, and assert a shell script with
+# the same line is NOT flagged, so the scoping is deliberate and tested rather
+# than an accident of the regex.
+cat > "$tmp/probe-workflow.yml" <<'PROBE'
+name: probe
+jobs:
+  build:
+    steps:
+      - run: |
+          if [ ! -d "chromium/src/.git" ]; then
+            tools/sync-sources.sh
+          else
+            echo "cached, skipping fetch"
+          fi
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-workflow.yml"
+harness::assert_status 1 "a workflow branching on .git existence"
+harness::assert_output_contains "cache-as-source-of-truth" "rule name"
+
+cat > "$tmp/probe-bootstrap.sh" <<'PROBE'
+#!/usr/bin/env bash
+if [ ! -d "$dir/.git" ]; then
+    git clone "$url" "$dir"
+fi
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-bootstrap.sh"
+harness::assert_status 0 "a script bootstrapping a missing checkout is allowed"
 
 # --- The scanner must not fire on descriptions of the patterns ---------------
 #
@@ -127,7 +162,7 @@ harness::assert_status 0 "comments, strings and heredoc bodies must not trip the
 
 cat > "$tmp/probe-allow.sh" <<'PROBE'
 #!/usr/bin/env bash
-# astro-allow: destination is the install directory under $HOME
+# astro-allow:rsync-delete destination is the install directory under $HOME
 rsync -a --delete "$BUILD_DIR/" "$INSTALL_DIR/"
 PROBE
 
@@ -141,6 +176,304 @@ PROBE
 
 harness::run python3 "$SCANNER" "$tmp/probe-unmarked.sh"
 harness::assert_status 1 "the same line without a marker is rejected"
+
+# --- The marker must not be forgeable ----------------------------------------
+#
+# The exception used to be a bare substring test against the RAW line:
+#
+#     allowed = ALLOW_MARKER in raw or ALLOW_MARKER in previous
+#
+# so a string literal, an executable line above, a marker naming no rule, one
+# naming the WRONG rule, and one carrying no justification all waved a banned
+# command straight through — and a single marker switched off every rule on the
+# line at once. Each shape is planted below and must be reported.
+#
+# Every case asserts on the scanner's OUTPUT, not just its status: a fix that
+# rejected every marker unconditionally would satisfy the exit codes while
+# breaking the exceptions this repository legitimately relies on, so the
+# well-formed cases at the end are as load-bearing as the forged ones.
+
+# assert_scan_reports <probe> <rule> <line> <what>
+assert_scan_reports() {
+    local probe="$1" rule="$2" line="$3" what="$4"
+    harness::run python3 "$SCANNER" "$probe"
+    harness::assert_status 1 "$what"
+    harness::assert_output_contains "$probe:$line: $rule:" "$what: reports $rule at line $line"
+}
+
+# assert_scan_clean <probe> <what>
+assert_scan_clean() {
+    local probe="$1" what="$2"
+    harness::run python3 "$SCANNER" "$probe"
+    harness::assert_status 0 "$what"
+    harness::assert_output_contains "no banned patterns" "$what: reports a clean scan"
+}
+
+# A marker inside a STRING is not a comment, whether or not it carries a '#'.
+cat > "$tmp/probe-forge-string.sh" <<'PROBE'
+#!/usr/bin/env bash
+echo "astro-allow:rsync-delete pretend" && rsync -a --delete "$src/" "$dst/"
+echo "# astro-allow:rsync-delete looks like a comment" && rsync -a --delete "$a/" "$b/"
+PROBE
+assert_scan_reports "$tmp/probe-forge-string.sh" rsync-delete 2 \
+    "a marker inside a string literal is not an exception"
+assert_scan_reports "$tmp/probe-forge-string.sh" rsync-delete 3 \
+    "a quoted '#' does not make a string a comment"
+
+# An EXECUTABLE line above must not hand an exception to the line below, even
+# when it carries a well-formed marker in a real trailing comment: the marker
+# is associated with ITS line, not the next one.
+cat > "$tmp/probe-forge-previous.sh" <<'PROBE'
+#!/usr/bin/env bash
+echo "astro-allow:rsync-delete pretend"
+rsync -a --delete "$src/" "$dst/"
+echo hello   # astro-allow:rsync-delete a real comment, but not a pure comment line
+rsync -a --delete "$a/" "$b/"
+PROBE
+assert_scan_reports "$tmp/probe-forge-previous.sh" rsync-delete 3 \
+    "executable code above does not grant an exception"
+assert_scan_reports "$tmp/probe-forge-previous.sh" rsync-delete 5 \
+    "a trailing marker on a code line does not carry to the next line"
+
+# A marker must name the rule it suppresses, and justify itself.
+cat > "$tmp/probe-forge-norule.sh" <<'PROBE'
+#!/usr/bin/env bash
+rsync -a --delete "$src/" "$dst/"   # astro-allow: no rule id at all
+PROBE
+assert_scan_reports "$tmp/probe-forge-norule.sh" rsync-delete 2 \
+    "a marker naming no rule is not an exception"
+
+cat > "$tmp/probe-forge-wrongrule.sh" <<'PROBE'
+#!/usr/bin/env bash
+rsync -a --delete "$src/" "$dst/"   # astro-allow:fuzzy-patch names a different rule entirely
+PROBE
+assert_scan_reports "$tmp/probe-forge-wrongrule.sh" rsync-delete 2 \
+    "a marker naming a different rule does not suppress this one"
+
+cat > "$tmp/probe-forge-nojustification.sh" <<'PROBE'
+#!/usr/bin/env bash
+rsync -a --delete "$src/" "$dst/"   # astro-allow:rsync-delete
+PROBE
+assert_scan_reports "$tmp/probe-forge-nojustification.sh" rsync-delete 2 \
+    "a marker with a rule id but no justification is not an exception"
+
+# One marker must suppress ONLY the rule it names. This line breaks three rules
+# and excuses one, so the other two must still be reported.
+cat > "$tmp/probe-scoped.sh" <<'PROBE'
+#!/usr/bin/env bash
+rsync -a --delete "$s/" "$d/" 2>/dev/null || true   # astro-allow:rsync-delete the destination is under $HOME
+PROBE
+assert_scan_reports "$tmp/probe-scoped.sh" suppressed-failure 2 \
+    "a scoped marker leaves the other rules in force"
+harness::assert_output_contains "$tmp/probe-scoped.sh:2: suppressed-stderr:" \
+    "the scoped marker did not suppress suppressed-stderr either"
+harness::assert_output_lacks "$tmp/probe-scoped.sh:2: rsync-delete:" \
+    "the rule the marker names is the one it suppresses"
+
+# An exception must not leak past the line it precedes.
+cat > "$tmp/probe-no-leak.sh" <<'PROBE'
+#!/usr/bin/env bash
+# astro-allow:rsync-delete the destination is under $HOME, verified above
+rsync -a --delete "$one/" "$two/"
+rsync -a --delete "$three/" "$four/"
+PROBE
+assert_scan_reports "$tmp/probe-no-leak.sh" rsync-delete 4 \
+    "an exception does not reach a third line"
+harness::assert_output_lacks "$tmp/probe-no-leak.sh:3: rsync-delete:" \
+    "the line the exception covers is still allowed"
+
+# A heredoc body is data, and must not grant an exception to what follows it.
+cat > "$tmp/probe-heredoc-grant.sh" <<'PROBE'
+#!/usr/bin/env bash
+cat <<'INNER'
+# astro-allow:rsync-delete this is heredoc data, not a comment
+INNER
+rsync -a --delete "$src/" "$dst/"
+PROBE
+assert_scan_reports "$tmp/probe-heredoc-grant.sh" rsync-delete 5 \
+    "a heredoc body does not grant an exception"
+
+# --- and the well-formed exceptions must still be honoured -------------------
+
+cat > "$tmp/probe-good-trailing.sh" <<'PROBE'
+#!/usr/bin/env bash
+rsync -a --delete "$s/" "$d/"   # astro-allow:rsync-delete destination is under $HOME, verified above
+PROBE
+assert_scan_clean "$tmp/probe-good-trailing.sh" \
+    "a trailing comment naming the rule with a justification is allowed"
+
+cat > "$tmp/probe-good-above.sh" <<'PROBE'
+#!/usr/bin/env bash
+# astro-allow:rsync-delete destination is under $HOME, verified above
+rsync -a --delete "$s/" "$d/"
+PROBE
+assert_scan_clean "$tmp/probe-good-above.sh" \
+    "a pure comment line directly above the command is allowed"
+
+# A line that genuinely breaks two rules carries one marker per rule.
+cat > "$tmp/probe-good-two.sh" <<'PROBE'
+#!/usr/bin/env bash
+probe 2>/dev/null || true   # astro-allow:suppressed-stderr the probe has no diagnostics astro-allow:suppressed-failure absence is the answer being asked for
+PROBE
+assert_scan_clean "$tmp/probe-good-two.sh" \
+    "two markers on one line each suppress the rule they name"
+
+# The same grammar in a workflow file, where '#' is a YAML comment.
+cat > "$tmp/probe-forge-workflow.yml" <<'PROBE'
+name: probe
+jobs:
+  build:
+    steps:
+      - run: echo "astro-allow:mutable-action-tag pretend"
+      - uses: actions/checkout@v4
+PROBE
+assert_scan_reports "$tmp/probe-forge-workflow.yml" mutable-action-tag 6 \
+    "a forged marker in a workflow is not an exception"
+
+cat > "$tmp/probe-good-workflow.yml" <<'PROBE'
+name: probe
+jobs:
+  build:
+    steps:
+      # astro-allow:mutable-action-tag pinned by digest in the reusable workflow
+      - uses: actions/checkout@v4
+PROBE
+assert_scan_clean "$tmp/probe-good-workflow.yml" \
+    "a well-formed YAML comment exception is honoured"
+
+# --- Continued logical lines -------------------------------------------------
+#
+# Scanning PHYSICAL lines was a second bypass, and a worse one than the marker
+# forgery above: it needed no marker at all. A string opened on one physical
+# line and closed on the next left the closing quote reading as an OPENING one,
+# so everything after it counted as quoted text and was never scanned. This
+# reported nothing:
+#
+#     astro::info "a message that spans \
+#         two physical lines" && rm -f /tmp/x || true
+#
+# Findings are reported against the logical line's FIRST physical line, which
+# is where a reader's eye and `git blame` both land, so the line number in the
+# assertions below is deliberately the start of the construct rather than the
+# physical line the banned text sits on.
+
+cat > "$tmp/probe-continued.sh" <<'PROBE'
+#!/usr/bin/env bash
+astro::info "a message that spans \
+    two physical lines" && rm -f /tmp/nothing || true
+PROBE
+assert_scan_reports "$tmp/probe-continued.sh" suppressed-failure 2 \
+    "a quote closed on the next physical line no longer hides the line"
+
+# Every rule, each split across a continuation, each reported at its start.
+cat > "$tmp/probe-continued-all.sh" <<'PROBE'
+#!/usr/bin/env bash
+rsync -a \
+    --delete "$a/" "$b/"
+git apply \
+    --3way "$p"
+patch -p1 \
+    -F3 < "$p"
+ninja chrome \
+    2>/dev/null
+git \
+    pull
+PROBE
+assert_scan_reports "$tmp/probe-continued-all.sh" rsync-delete 2 \
+    "rsync --delete split across a continuation"
+assert_scan_reports "$tmp/probe-continued-all.sh" git-apply-3way 4 \
+    "git apply --3way split across a continuation"
+assert_scan_reports "$tmp/probe-continued-all.sh" fuzzy-patch 6 \
+    "patch -F3 split across a continuation"
+assert_scan_reports "$tmp/probe-continued-all.sh" suppressed-stderr 8 \
+    "2>/dev/null split across a continuation"
+assert_scan_reports "$tmp/probe-continued-all.sh" unconstrained-pull 10 \
+    "git pull split across a continuation"
+
+# An ESCAPED backslash ends the line. Asserting the finding lands on line 3 and
+# NOT line 2 is what tells a correct join from one that swallows any trailing
+# backslash it sees.
+cat > "$tmp/probe-escaped-backslash.sh" <<'PROBE'
+#!/usr/bin/env bash
+printf 'a literal backslash argument' \\
+rsync -a --delete "$a/" "$b/"
+PROBE
+assert_scan_reports "$tmp/probe-escaped-backslash.sh" rsync-delete 3 \
+    "an escaped backslash does not continue the line"
+harness::assert_output_lacks "$tmp/probe-escaped-backslash.sh:2: rsync-delete:" \
+    "the escaped-backslash line is not joined to the one below it"
+
+# A comment runs to the end of its PHYSICAL line, so a backslash inside one
+# continues nothing. If it did, the comment would swallow the command beneath.
+cat > "$tmp/probe-comment-backslash.sh" <<'PROBE'
+#!/usr/bin/env bash
+# a comment that happens to end in a backslash \
+rsync -a --delete "$a/" "$b/"
+PROBE
+assert_scan_reports "$tmp/probe-comment-backslash.sh" rsync-delete 3 \
+    "a backslash in a comment does not swallow the next line"
+
+# Heredoc handling must win over the join. The body line below ends in a
+# backslash directly above the terminator: if the join applied inside a heredoc
+# it would absorb the terminator, the heredoc would never close, and every
+# banned pattern in the rest of the file would be skipped as heredoc data.
+cat > "$tmp/probe-heredoc-continuation.sh" <<'PROBE'
+#!/usr/bin/env bash
+cat <<'INNER'
+rsync -a --delete /a /b || true
+body text ending in a backslash \
+INNER
+rsync -a --delete "$a/" "$b/"
+PROBE
+assert_scan_reports "$tmp/probe-heredoc-continuation.sh" rsync-delete 6 \
+    "a heredoc body does not join across its terminator"
+harness::assert_output_lacks "$tmp/probe-heredoc-continuation.sh:3: rsync-delete:" \
+    "the heredoc body itself is still not scanned"
+
+# --- Markers must keep working on a joined line ------------------------------
+#
+# The two real markers in tools/sync-sources.sh and tools/apply-patches.sh sit
+# on exactly this shape, and became load-bearing for the first time when the
+# join closed the gap: before it, the `|| true` they excuse was invisible.
+
+cat > "$tmp/probe-continued-marked.sh" <<'PROBE'
+#!/usr/bin/env bash
+artifacts="$(git status --porcelain \
+    | grep -E '\.rej$' | head -5)" || true   # astro-allow:suppressed-failure grep finding nothing is the normal case
+PROBE
+assert_scan_clean "$tmp/probe-continued-marked.sh" \
+    "a trailing marker at the end of a joined logical line is honoured"
+
+cat > "$tmp/probe-continued-unmarked.sh" <<'PROBE'
+#!/usr/bin/env bash
+artifacts="$(git status --porcelain \
+    | grep -E '\.rej$' | head -5)" || true
+PROBE
+assert_scan_reports "$tmp/probe-continued-unmarked.sh" suppressed-failure 2 \
+    "the same joined line without a marker is reported"
+
+# A pure comment line above the logical line's FIRST physical line grants it.
+cat > "$tmp/probe-continued-above.sh" <<'PROBE'
+#!/usr/bin/env bash
+# astro-allow:rsync-delete destination is under $HOME, verified above
+rsync -a \
+    --delete "$a/" "$b/"
+PROBE
+assert_scan_clean "$tmp/probe-continued-above.sh" \
+    "a comment above the first physical line grants the whole logical line"
+
+# ...and the grant stops at the end of the logical line, however long it is.
+cat > "$tmp/probe-continued-leak.sh" <<'PROBE'
+#!/usr/bin/env bash
+# astro-allow:rsync-delete destination is under $HOME, verified above
+rsync -a \
+    --delete "$one/" "$two/"
+rsync -a --delete "$three/" "$four/"
+PROBE
+assert_scan_reports "$tmp/probe-continued-leak.sh" rsync-delete 5 \
+    "an exception does not leak past the end of a joined logical line"
+harness::assert_output_lacks "$tmp/probe-continued-leak.sh:3: rsync-delete:" \
+    "the joined line the exception covers is still allowed"
 
 # --- The specific regressions this issue exists to prevent -------------------
 
@@ -165,5 +498,157 @@ fi
 if grep -qE '^[^#]*patch -p1[^#]*-F[0-9]' "${PRODUCTION_SCRIPTS[@]}"; then
     harness::fail "the fuzzy patch fallbacks must stay removed"
 fi
+
+# The two shapes ASTRO-NEXT-002 removed, checked by name so a reviewer sees
+# what is being guarded rather than only a rule id.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 2))
+if grep -rq 'skipping fetch' "$ASTRO_ROOT/.github/workflows/"; then
+    harness::fail "CI must not skip source synchronisation because a cache exists"
+fi
+if grep -qE '^[^#]*git .*\bpull\b' "${PRODUCTION_SCRIPTS[@]}"; then
+    harness::fail "no build dependency may be updated with an unconstrained git pull"
+fi
+
+
+# --- Backslash continuations: a bypass needing no marker at all --------------
+#
+# The scanner read PHYSICAL lines. A string opened on one physical line and
+# closed on the next left the closing quote reading as an OPENING one, so
+# everything after it — `|| true` included — counted as quoted text and was
+# never scanned. Measured before the fix: the probe below reported
+# `no banned patterns` and exited 0.
+#
+# This one required nobody to type anything. The astro-allow bypass at least
+# needed a marker; this disarmed the epic's central rule for free.
+
+cat > "$tmp/probe-continuation.sh" <<'PROBE'
+#!/usr/bin/env bash
+astro::info "a message that spans \
+    two physical lines" && rm -f /tmp/x || true
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-continuation.sh"
+harness::assert_nonzero_status "a banned pattern on a continued logical line"
+harness::assert_output_contains "suppressed-failure" "names the rule"
+harness::assert_output_contains "probe-continuation.sh:2:" \
+    "reports the logical line's FIRST physical line, where the construct starts"
+
+# The other direction: a correct marker at the end of the logical line must
+# still be honoured, or the fix would simply reject every continued line.
+cat > "$tmp/probe-continuation-allowed.sh" <<'PROBE'
+#!/usr/bin/env bash
+astro::info "a message that spans \
+    two physical lines" && rm -f /tmp/x || true   # astro-allow:suppressed-failure the probe tolerates a missing file
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-continuation-allowed.sh"
+harness::assert_status 0 "a marker at the end of a continued logical line"
+
+# A pure-comment line above the FIRST physical line of a continued construct
+# is still immediately associated with it.
+cat > "$tmp/probe-continuation-above.sh" <<'PROBE'
+#!/usr/bin/env bash
+# astro-allow:suppressed-failure the probe tolerates a missing file
+astro::info "a message that spans \
+    two physical lines" && rm -f /tmp/x || true
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-continuation-above.sh"
+harness::assert_status 0 "a marker on the line above a continued construct"
+
+# An ESCAPED backslash ends the line. Treating `\\` as a continuation would
+# swallow the NEXT line into this one and hide whatever it contains.
+cat > "$tmp/probe-escaped-backslash.sh" <<'PROBE'
+#!/usr/bin/env bash
+printf 'a backslash: \\'
+rm -f /tmp/x || true
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-escaped-backslash.sh"
+harness::assert_nonzero_status "an escaped backslash does not continue the line"
+harness::assert_output_contains "probe-escaped-backslash.sh:3:" \
+    "the violation is reported on its own line, not folded into the one above"
+
+# A trailing backslash inside a COMMENT is ordinary text: a comment ends at the
+# newline and cannot be continued. Treating it as one would hide the next line.
+cat > "$tmp/probe-backslash-in-comment.sh" <<'PROBE'
+#!/usr/bin/env bash
+echo hi   # this comment ends with a backslash \
+rm -f /tmp/x || true
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-backslash-in-comment.sh"
+harness::assert_nonzero_status "a backslash inside a comment does not continue the line"
+
+# Heredoc bodies are data, and a backslash in one continues nothing. The
+# terminator must still be recognised on its own physical line.
+cat > "$tmp/probe-continuation-heredoc.sh" <<'PROBE'
+#!/usr/bin/env bash
+cat > /tmp/x <<'INNER'
+a heredoc body line ending in a backslash \
+INNER
+rm -f /tmp/x || true
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-continuation-heredoc.sh"
+harness::assert_nonzero_status "the line after a heredoc is still scanned"
+harness::assert_output_contains "probe-continuation-heredoc.sh:5:" \
+    "the heredoc body did not swallow the line after its terminator"
+
+# The five markers the repository actually carries must every one be
+# load-bearing. Before continuations were joined, two of them suppressed
+# nothing — they sat on exactly this shape — so a reader could not tell a
+# reviewed exception from a decorative comment.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 2))
+stripped="$tmp/stripped"
+mkdir -p "$stripped"
+for marked in "$ASTRO_ROOT"/tools/sync-sources.sh "$ASTRO_ROOT"/tools/apply-patches.sh \
+              "$ASTRO_ROOT"/tools/install-local.sh "$ASTRO_ROOT"/tools/lib/astro-common.sh; do
+    sed 's/#[[:space:]]*astro-allow:[^"]*$//' "$marked" > "$stripped/$(basename "$marked")"
+done
+stripped_status=0
+python3 "$SCANNER" "$stripped"/*.sh > "$tmp/stripped-scan.txt" 2>&1 || stripped_status=$?
+# Exit 1 is "findings reported". Exit 2 is "nothing was scanned", and a crash
+# is anything else — both would leave the count at 0, which the check below
+# would read as a marker problem rather than as a broken measurement.
+if [ "$stripped_status" -ne 1 ]; then
+    harness::fail "scanning the stripped copies should report findings (exit 1), got exit $stripped_status"
+fi
+found="$(awk '/^[^ ]+:[0-9]+: /{n++} END{print n+0}' "$tmp/stripped-scan.txt")"
+if [ "$found" -ne 5 ]; then
+    harness::fail "expected all 5 committed astro-allow markers to be load-bearing, \
+but stripping them surfaced $found finding(s). A marker that suppresses nothing is a \
+comment pretending to be a reviewed exception."
+fi
+
+# --- A quote continues a logical line with no backslash at all ---------------
+#
+# The backslash join closed one instance of the defect; an unterminated quote
+# continues a logical line too, and hid everything after it by the same
+# mechanism. Joining on either closes the class rather than one shape.
+
+cat > "$tmp/probe-unterminated-quote.sh" <<'PROBE'
+#!/usr/bin/env bash
+astro::info "a message spanning
+two lines with no backslash" && rm -f /tmp/x || true
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-unterminated-quote.sh"
+harness::assert_nonzero_status "a banned pattern after a multi-line string"
+harness::assert_output_contains "suppressed-failure" "names the rule"
+harness::assert_output_contains "probe-unterminated-quote.sh:2:" \
+    "reported against the line where the string opens"
+
+# And the marker still reaches it, so the class is closed in both directions.
+cat > "$tmp/probe-unterminated-quote-allowed.sh" <<'PROBE'
+#!/usr/bin/env bash
+astro::info "a message spanning
+two lines with no backslash" && rm -f /tmp/x || true   # astro-allow:suppressed-failure the probe tolerates a missing file
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-unterminated-quote-allowed.sh"
+harness::assert_status 0 "a marker at the end of a quote-continued logical line"
+
+# A single-quoted string spanning lines behaves the same; without this the fix
+# could be double-quote-only and nobody would know.
+cat > "$tmp/probe-single-quote-span.sh" <<'PROBE'
+#!/usr/bin/env bash
+astro::info 'a message spanning
+two lines' && rm -f /tmp/x || true
+PROBE
+harness::run python3 "$SCANNER" "$tmp/probe-single-quote-span.sh"
+harness::assert_nonzero_status "a single-quoted string spanning lines hides nothing either"
 
 harness::pass

--- a/tools/tests/cases/provenance-records-what-is-on-disk.sh
+++ b/tools/tests/cases/provenance-records-what-is-on-disk.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Provenance must describe the build that actually happened.
+#
+# It is generated from what is ON DISK, never from browser.lock.json. A
+# provenance file derived from the lock would only restate the lock, and would
+# certify a stale runner's build as correct — which is exactly the failure the
+# lock exists to catch.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+SYNC="$ASTRO_ROOT/tools/sync-sources.sh"
+PROVENANCE="$ASTRO_ROOT/tools/generate-provenance.sh"
+tmp="$(harness::tmpdir)"
+
+harness::assert_file_exists "$PROVENANCE"
+
+origins="$tmp/origins"
+mkdir -p "$origins"
+mapfile -t CHROMIUM_SHAS < <(harness::make_source_repo "$origins/chromium" chromium sentinels)
+CHROMIUM_TIP="${CHROMIUM_SHAS[2]}"
+CHROMIUM_OLD="${CHROMIUM_SHAS[0]}"
+mapfile -t DEPOT_SHAS < <(harness::make_source_repo "$origins/depot_tools" depot_tools)
+mapfile -t UNGOOGLED_SHAS < <(harness::make_source_repo "$origins/ungoogled" ungoogled)
+
+lock="$tmp/browser.lock.json"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$tmp/browser.lock.schema.json"
+harness::write_lock "$lock" \
+    "file://$origins/chromium" "$CHROMIUM_TIP" \
+    "file://$origins/depot_tools" "${DEPOT_SHAS[2]}" \
+    "file://$origins/ungoogled" "${UNGOOGLED_SHAS[2]}"
+
+work="$tmp/work"
+mkdir -p "$work/chromium"
+src="$work/chromium/src"
+
+harness::run env ASTRO_CHROMIUM_SRC="$src" "$SYNC" --no-deps --lock "$lock" \
+    --chromium-src "$src" --depot-tools "$work/depot_tools" --ungoogled "$work/ungoogled"
+harness::assert_status 0 "sync fixtures into place"
+
+gn_args="$tmp/linux.gn"
+cat > "$gn_args" <<'EOF'
+# a comment that must not appear as an argument
+is_debug = false
+symbol_level = 1
+EOF
+
+out="$tmp/provenance.json"
+generate() {
+    harness::run env ASTRO_CHROMIUM_SRC="$src" "$PROVENANCE" \
+        --lock "$lock" --output "$out" --gn-args "$gn_args" \
+        --platform linux --build-type Release \
+        --chromium-src "$src" --depot-tools "$work/depot_tools" \
+        --ungoogled "$work/ungoogled" "$@"
+}
+
+# --- Matching tree ----------------------------------------------------------
+
+generate
+harness::assert_status 0 "provenance for a tree matching the lock"
+harness::assert_file_exists "$out"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$out" "$CHROMIUM_TIP" "${DEPOT_SHAS[2]}" "$gn_args" <<'PY' || exit 1
+import json, subprocess, sys
+
+path, chromium_tip, depot_tip, gn_args = sys.argv[1:5]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+
+sources = document["sources"]
+
+# Recorded revisions must match the actual repositories, not the lock.
+assert sources["chromium"]["on_disk"] == chromium_tip, sources["chromium"]
+assert sources["chromium"]["locked"] == chromium_tip, sources["chromium"]
+assert sources["depot_tools"]["on_disk"] == depot_tip, sources["depot_tools"]
+
+# Astro's own revision is resolved here, not carried in the lock.
+assert sources["astro"]["locked"] is None, sources["astro"]
+real_astro = subprocess.run(
+    ["git", "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+).stdout.strip()
+assert sources["astro"]["on_disk"] == real_astro, (sources["astro"], real_astro)
+
+assert document["drift"] == [], document["drift"]
+# `reproducible` also depends on the Astro repository's own worktree, which a
+# test cannot control — a developer running the suite mid-change legitimately
+# has uncommitted files. Assert what this case actually governs: the synced
+# source trees are clean and match.
+assert "chromium" not in document["dirty_worktrees"], document["dirty_worktrees"]
+assert "depot_tools" not in document["dirty_worktrees"], document["dirty_worktrees"]
+
+# GN args are recorded literally as well as by hash: a hash proves two builds
+# match but does not say what either was built with.
+assert document["gn_args"]["path"] == gn_args
+assert document["gn_args"]["args"] == ["is_debug = false", "symbol_level = 1"], \
+    document["gn_args"]["args"]
+assert len(document["gn_args"]["sha256"]) == 64
+
+assert document["target"] == {"platform": "linux", "build_type": "Release"}, document["target"]
+assert document["toolchain"]["compiler_version"], document["toolchain"]
+
+# A wall-clock timestamp would make two builds of identical sources differ.
+assert document["timestamp_policy"] == "excluded-from-build-inputs", document
+assert "timestamp" not in document
+PY
+
+# --- Drift is reported, not smoothed over -----------------------------------
+
+git -C "$src" checkout --quiet --detach "$CHROMIUM_OLD"
+
+generate
+harness::assert_status 0 "provenance for a drifted tree (reported, not fatal by default)"
+harness::assert_output_contains "DRIFT" "drift is announced"
+harness::assert_output_contains "$CHROMIUM_OLD" "names the commit actually on disk"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$out" "$CHROMIUM_OLD" "$CHROMIUM_TIP" <<'PY' || exit 1
+import json, sys
+path, on_disk, locked = sys.argv[1:4]
+with open(path, encoding="utf-8") as handle:
+    document = json.load(handle)
+assert document["sources"]["chromium"]["on_disk"] == on_disk, document["sources"]["chromium"]
+assert document["sources"]["chromium"]["locked"] == locked, document["sources"]["chromium"]
+assert document["drift"], "drift must be recorded"
+assert document["reproducible"] is False, document
+assert any("chromium" in line for line in document["drift"]), document["drift"]
+PY
+
+# --require-match is what a release build uses.
+generate --require-match
+harness::assert_nonzero_status "--require-match against a drifted tree"
+harness::assert_output_contains "does not correspond to the lock" "refusal reason"
+
+# --- A dirty worktree is recorded too ---------------------------------------
+
+git -C "$src" checkout --quiet --detach "$CHROMIUM_TIP"
+printf 'local edit\n' >> "$src/content.txt"
+
+generate
+harness::assert_status 0 "provenance for a dirty tree"
+harness::assert_output_contains "DIRTY" "dirty worktree is announced"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+python3 - "$out" <<'PY' || exit 1
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as handle:
+    document = json.load(handle)
+assert "chromium" in document["dirty_worktrees"], document["dirty_worktrees"]
+assert document["reproducible"] is False, document
+PY
+
+generate --require-match
+harness::assert_nonzero_status "--require-match against a dirty tree"
+
+harness::pass

--- a/tools/tests/cases/real-checkout-lock-hazards.sh
+++ b/tools/tests/cases/real-checkout-lock-hazards.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# The hazard a real checkout exposed in the step that FETCHES the locked
+# sources, as opposed to the ones that build from them:
+#
+#   * a failed `git fetch` keeps nothing. Telling a user their retry resumes is
+#     a promise git does not make, and acting on it wastes the one thing a bad
+#     link has none of.
+#
+# Its siblings — `find … | head` dying of SIGPIPE, and a tracked `.orig` being
+# upstream content rather than a patch artifact — belong to the build pipeline
+# and live in real-checkout-hazards.sh. This one is split out because
+# tools/sync-sources.sh does not exist at that layer, so a single case could
+# not run there.
+#
+# The hazard gets a demonstration that it is real AND a guard on the wording,
+# because a promise nobody can justify is a promise somebody restores.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+tmp="$(harness::tmpdir)"
+
+count_git_objects() {
+    git -C "$1" count-objects -v | awk '/^(count|in-pack):/ { total += $2 } END { print total + 0 }'
+}
+
+source_repo="$tmp/fetch-source"
+harness::make_source_repo "$source_repo" "fetch-fixture" > "$tmp/fetch-source.shas"
+
+# Control first: without it, "zero objects" proves the fetch kept nothing OR
+# that count_git_objects cannot see objects at all.
+dest_ok="$tmp/fetch-dest-ok"
+git init --quiet "$dest_ok"
+git -C "$dest_ok" remote add origin "$source_repo"
+before_ok="$(count_git_objects "$dest_ok")"
+
+harness::run git -C "$dest_ok" fetch --quiet origin "+refs/heads/main:refs/remotes/origin/main"
+harness::assert_status 0 "control: a fetch from a real repository succeeds"
+
+after_ok="$(count_git_objects "$dest_ok")"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ "$after_ok" -le "$before_ok" ]; then
+    harness::fail "control is vacuous: a successful fetch left the object count at $after_ok, so a zero count below would prove nothing"
+fi
+
+dest_bad="$tmp/fetch-dest-bad"
+git init --quiet "$dest_bad"
+git -C "$dest_bad" remote add origin "$tmp/no-such-repository.git"
+
+harness::run git -C "$dest_bad" fetch origin "+refs/heads/main:refs/remotes/origin/main"
+harness::assert_nonzero_status "a fetch from a remote that does not exist"
+
+after_bad="$(count_git_objects "$dest_bad")"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ "$after_bad" != "0" ]; then
+    harness::fail "a failed fetch left $after_bad object(s) behind; the retry advice below depends on it leaving none"
+fi
+
+packs="$(ls -A "$dest_bad/.git/objects/pack")"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ -n "$packs" ]; then
+    harness::fail "a failed fetch left pack files behind: $packs"
+fi
+
+# The wording must not promise otherwise. Intent, not sentences: a rewrite that
+# still says every attempt starts from scratch has to keep passing, and only a
+# claim that the partial transfer survives may fail.
+SYNC_SOURCES="$ASTRO_ROOT/tools/sync-sources.sh"
+harness::assert_file_exists "$SYNC_SOURCES"
+
+FETCH_FALSE_PROMISES=(
+    'where it left off'
+    'picks? up where'
+    'resumes the (partial|failed|interrupted) (transfer|fetch|download)'
+    '(partial|interrupted|failed) (transfer|fetch|download) is (kept|preserved|retained|reused)'
+    'keeps (what|the bytes|the objects) (it |already )?(downloaded|transferred)'
+    'already (downloaded|transferred) (objects|data|bytes) are (kept|reused|retained)'
+)
+
+# Vacuity floor for the loop below. A truncated array asserts nothing while
+# still exiting zero, which is indistinguishable from a script that makes no
+# false promises.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ "${#FETCH_FALSE_PROMISES[@]}" -lt 6 ]; then
+    harness::fail "only ${#FETCH_FALSE_PROMISES[@]} false-promise pattern(s) declared; the list has been truncated"
+fi
+
+for promise in "${FETCH_FALSE_PROMISES[@]}"; do
+    promise_hits=""
+    promise_status=0
+    promise_hits="$(grep -inE "$promise" "$SYNC_SOURCES")" || promise_status=$?
+    HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+    if [ "$promise_status" -gt 1 ]; then
+        harness::fail "grep for the false promise '$promise' failed (exit $promise_status)"
+    fi
+    if [ -n "$promise_hits" ]; then
+        harness::fail "tools/sync-sources.sh promises a failed fetch keeps what it downloaded ('$promise'):
+$promise_hits"
+    fi
+done
+
+# Mutation support for the loop above: a pattern set that matched nothing at all
+# would report the script clean whatever it said. A probe carrying one sentence
+# of each forbidden shape proves the patterns still fire.
+cat > "$tmp/probe-false-promises.txt" <<'PROBE'
+The retry continues from where it left off.
+A second attempt picks up where the first stopped.
+It resumes the partial transfer rather than starting again.
+The interrupted download is preserved between attempts.
+It keeps the bytes it downloaded.
+Already transferred objects are reused on the next attempt.
+PROBE
+
+for promise in "${FETCH_FALSE_PROMISES[@]}"; do
+    probe_hits=0
+    probe_status=0
+    probe_hits="$(grep -icE "$promise" "$tmp/probe-false-promises.txt")" || probe_status=$?
+    HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+    if [ "$probe_status" -gt 1 ]; then
+        harness::fail "grep of the false-promise probe failed (exit $probe_status) for '$promise'"
+    fi
+    if [ "$probe_hits" -lt 1 ]; then
+        harness::fail "the false-promise pattern '$promise' matches nothing even in the probe; it would report any wording clean"
+    fi
+done
+
+# The positive half. Two occurrences are required because two different people
+# read two different messages: the warning printed on every retry, and the fatal
+# hint printed when the attempts run out. Either one alone leaves half the
+# audience deciding to wait it out on a link that will never finish.
+FETCH_STARTS_OVER='(every|each) attempt starts|retrying from the start|not a resumable operation|discards its partial transfer'
+starts_over=0
+starts_over_status=0
+starts_over="$(grep -icE "$FETCH_STARTS_OVER" "$SYNC_SOURCES")" || starts_over_status=$?
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ "$starts_over_status" -gt 1 ]; then
+    harness::fail "grep for the start-over wording failed (exit $starts_over_status)"
+fi
+if [ "$starts_over" -lt 2 ]; then
+    harness::fail "tools/sync-sources.sh states only $starts_over time(s) that a failed fetch starts over; both the retry warning and the final hint must say so"
+fi
+
+harness::pass

--- a/tools/tests/cases/release-jobs-are-platform-explicit.sh
+++ b/tools/tests/cases/release-jobs-are-platform-explicit.sh
@@ -1,0 +1,510 @@
+#!/usr/bin/env bash
+# Every release build job must name the gclient target_os it synchronises for.
+#
+# Until this was fixed each job invoked tools/sync-sources.sh with no --targets,
+# so all five synced with the default (linux) and the Windows, macOS and Android
+# jobs were configured by whatever that runner's checkout had last been set to.
+# That is the same "the runner decides what gets built" defect the source lock
+# exists to remove, one level down in the dependency graph: the lock pins WHICH
+# commit is compiled, and nothing pinned what it is configured to compile FOR.
+#
+# The fix is one --targets argument per invocation, which nothing enforces. A
+# new job, or a copy-pasted one, silently reintroduces the defect. This case is
+# the enforcement.
+#
+# The --verify-only invocation is checked against its job's sync invocation
+# rather than only against the job: a verify naming a different target_os would
+# confirm a configuration nobody synced, which is worse than not verifying.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+WORKFLOW="$ASTRO_ROOT/.github/workflows/release.yml"
+SYNC_SCRIPT="$ASTRO_ROOT/tools/sync-sources.sh"
+tmp="$(harness::tmpdir)"
+
+harness::assert_file_exists "$WORKFLOW"
+harness::assert_file_exists "$SYNC_SCRIPT"
+
+# The checker lives in the fixture rather than in tools/, because the same code
+# has to read the real workflow AND the deliberately broken copies below. A
+# checker only ever pointed at a file that passes is indistinguishable from one
+# that cannot fail.
+CHECKER="$tmp/platform-targets.py"
+cat > "$CHECKER" <<'PY'
+#!/usr/bin/env python3
+"""Assert every build job in a release workflow names its gclient target_os.
+
+Stdlib only: PyYAML is not present on a clean machine or a self-hosted runner,
+and a gate that needs an install step is a gate somebody skips. A workflow is
+line-oriented enough for this question, which is the same parse the rest of
+this repository's checks use.
+
+Usage:
+    platform-targets.py check  <workflow.yml> <sync-sources.sh>
+    platform-targets.py mutate <workflow.yml> <job> <mode> [value]
+
+The mutate modes exist so the test can prove this checker discriminates:
+drop-targets, retarget-sync, retarget-verify, retarget-all, drop-job and
+clone-without-sync.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import namedtuple
+
+SYNC = "tools/sync-sources.sh"
+BUILD = "tools/build.sh"
+
+# What each tools/build.sh platform has to be synced as. Not an identity map,
+# and that is the whole point: Windows ARM64 is cross-compiled on a Windows x64
+# runner, so both Windows jobs need gclient's `win`.
+PLATFORM_TARGET = {
+    "linux": "linux",
+    "windows": "win",
+    "windows-arm64": "win",
+    "macos": "mac",
+    "android": "android",
+}
+
+# A parser that finds nothing must not report success over an empty set.
+MIN_BUILD_JOBS = 5
+MIN_INVOCATIONS = 10
+
+TARGETS = re.compile(r"--targets(?:=|\s+)(\"[^\"]*\"|'[^']*'|\S+)")
+JOB_HEADER = re.compile(r"^  ([A-Za-z0-9_.-]+):\s*$")
+
+# tools/sync-sources.sh validates target_os in exactly one `case` arm. Reading
+# it here rather than restating the list keeps the two from drifting apart.
+TARGET_CASE_ARM = re.compile(r"^\s*([a-z][a-z0-9|_-]*)\)\s*target_os_literal=")
+
+Invocation = namedtuple("Invocation", "line verify target")
+
+
+def die(message: str) -> None:
+    print(message, file=sys.stderr)
+    raise SystemExit(2)
+
+
+def read_lines(path: str) -> list[str]:
+    with open(path, encoding="utf-8") as handle:
+        return handle.read().splitlines()
+
+
+def strip_yaml_comment(line: str) -> str:
+    """Drop a trailing YAML comment, keeping quoted text.
+
+    Load-bearing rather than cosmetic: release.yml names tools/sync-sources.sh
+    in five prose comments, and counting those as invocations would report five
+    phantom missing --targets on a correct file.
+    """
+    quote = None
+    for index, char in enumerate(line):
+        if quote:
+            if char == quote:
+                quote = None
+            continue
+        if char in ("'", '"'):
+            quote = char
+            continue
+        if char == "#" and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+    return line
+
+
+def accepted_targets(path: str) -> set[str]:
+    found = [
+        match.group(1)
+        for match in (TARGET_CASE_ARM.match(line) for line in read_lines(path))
+        if match
+    ]
+    if len(found) != 1:
+        die(f"expected exactly one target_os case arm in {path}, found {len(found)}")
+    return set(found[0].split("|"))
+
+
+def split_jobs(lines: list[str]) -> list[tuple[str, int, int]]:
+    """Return (name, start, end) index ranges for each entry under `jobs:`."""
+    jobs: list[tuple[str, int, int]] = []
+    in_jobs = False
+    name = None
+    start = 0
+
+    for index, raw in enumerate(lines):
+        code = strip_yaml_comment(raw)
+        if not code.strip():
+            continue
+        if not code[0].isspace():
+            if name is not None:
+                jobs.append((name, start, index))
+                name = None
+            in_jobs = code.split(":", 1)[0].strip() == "jobs"
+            continue
+        if not in_jobs:
+            continue
+        match = JOB_HEADER.match(code)
+        if match:
+            if name is not None:
+                jobs.append((name, start, index))
+            name = match.group(1)
+            start = index
+
+    if name is not None:
+        jobs.append((name, start, len(lines)))
+    return jobs
+
+
+def invocations_in(lines: list[str], start: int, end: int) -> list[Invocation]:
+    found = []
+    for index in range(start, end):
+        code = strip_yaml_comment(lines[index])
+        if SYNC not in code:
+            continue
+        match = TARGETS.search(code)
+        target = match.group(1).strip("\"'") if match else None
+        found.append(Invocation(index + 1, "--verify-only" in code, target))
+    return found
+
+
+def build_platforms_in(lines: list[str], start: int, end: int) -> list[tuple[int, str]]:
+    """Every tools/build.sh invocation in the range, with the platform it names.
+
+    The platform is taken from the argument rather than the job name, so what
+    is asserted is that a job syncs for what it actually builds.
+    """
+    found = []
+    for index in range(start, end):
+        code = strip_yaml_comment(lines[index])
+        position = code.find(BUILD)
+        if position < 0:
+            continue
+        arguments = code[position + len(BUILD):].split()
+        known = [argument for argument in arguments if argument in PLATFORM_TARGET]
+        found.append((index + 1, known[0] if len(known) == 1 else None))
+    return found
+
+
+def check(workflow_path: str, sync_path: str) -> int:
+    lines = read_lines(workflow_path)
+    accepted = accepted_targets(sync_path)
+    required = set(PLATFORM_TARGET.values())
+    errors: list[str] = []
+
+    # A partial or misdirected parse of the case arm would silently narrow what
+    # counts as a valid target; this is the floor under it.
+    unsupported = required - accepted
+    if unsupported:
+        errors.append(
+            f"{SYNC} no longer accepts {', '.join(sorted(unsupported))}; "
+            "the job-to-target_os map in this checker needs revisiting"
+        )
+
+    jobs = split_jobs(lines)
+    build_jobs = 0
+    covered: set[str] = set()
+
+    for name, start, end in jobs:
+        builds = build_platforms_in(lines, start, end)
+        if not builds:
+            # A job that compiles nothing (the publish job) has no platform to
+            # be explicit about. Its invocations, if any, are still counted by
+            # the file-wide check below.
+            continue
+
+        build_jobs += 1
+        platforms = {platform for _line, platform in builds}
+        if None in platforms:
+            errors.append(
+                f"job {name}: invokes {BUILD} with no recognised platform argument"
+            )
+            continue
+        if len(platforms) > 1:
+            named = ", ".join(sorted(platforms))
+            errors.append(
+                f"job {name}: builds several platforms ({named}), "
+                "so no single --targets can be right for all of them"
+            )
+            continue
+
+        platform = platforms.pop()
+        expected = PLATFORM_TARGET[platform]
+        invocations = invocations_in(lines, start, end)
+        syncs = [item for item in invocations if not item.verify]
+        verifies = [item for item in invocations if item.verify]
+
+        if not syncs:
+            errors.append(f"job {name}: builds {platform} but never invokes {SYNC}")
+        if not verifies:
+            errors.append(
+                f"job {name}: never invokes {SYNC} --verify-only, so nothing "
+                "confirms the tree it is about to build"
+            )
+
+        for item in invocations:
+            kind = "--verify-only" if item.verify else "sync"
+            if item.target is None:
+                errors.append(
+                    f"job {name}: line {item.line}: the {kind} invocation carries "
+                    "no --targets, so it syncs with the default target_os and the "
+                    "runner decides what gets built"
+                )
+                continue
+            if item.target not in accepted:
+                allowed = ", ".join(sorted(accepted))
+                errors.append(
+                    f"job {name}: line {item.line}: --targets \"{item.target}\" is "
+                    f"not a target_os {SYNC} accepts ({allowed})"
+                )
+                continue
+            covered.add(item.target)
+
+        for item in syncs:
+            if item.target in accepted and item.target != expected:
+                errors.append(
+                    f"job {name}: builds {platform} but syncs with "
+                    f"--targets \"{item.target}\" (expected \"{expected}\")"
+                )
+
+        # With no sync at all — already reported above — there is nothing for
+        # the verify to agree with, so the platform stands in as the reference.
+        reference = {item.target for item in syncs if item.target} or {expected}
+        for item in verifies:
+            if item.target in accepted and item.target not in reference:
+                synced = ", ".join(sorted(reference))
+                errors.append(
+                    f"job {name}: line {item.line}: --verify-only uses "
+                    f"--targets \"{item.target}\" but the sync uses \"{synced}\"; "
+                    "it would verify a different configuration from the one synced"
+                )
+
+        print(
+            f"job {name}: builds {platform}, "
+            f"sync {[item.target for item in syncs]}, "
+            f"verify {[item.target for item in verifies]}"
+        )
+
+    every = invocations_in(lines, 0, len(lines))
+    explicit = [item for item in every if item.target is not None]
+    if len(explicit) != len(every):
+        bare = ", ".join(str(item.line) for item in every if item.target is None)
+        errors.append(
+            f"{len(every)} {SYNC} invocation(s) but only {len(explicit)} carry "
+            f"--targets; line(s) without: {bare}"
+        )
+
+    uncovered = required - covered
+    if uncovered:
+        errors.append(
+            f"no build job syncs with target_os {', '.join(sorted(uncovered))}; "
+            "a dropped platform must not go unnoticed"
+        )
+
+    if build_jobs < MIN_BUILD_JOBS:
+        errors.append(
+            f"vacuity floor: found {build_jobs} build job(s), expected at least "
+            f"{MIN_BUILD_JOBS}"
+        )
+    if len(every) < MIN_INVOCATIONS:
+        errors.append(
+            f"vacuity floor: found {len(every)} {SYNC} invocation(s), expected at "
+            f"least {MIN_INVOCATIONS}"
+        )
+
+    print(f"accepted target_os (read from {sync_path}): {', '.join(sorted(accepted))}")
+    print(f"platform coverage: {', '.join(sorted(covered))}")
+
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        print(f"\n{len(errors)} problem(s) in {workflow_path}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: {build_jobs} build job(s), {len(every)} {SYNC} invocation(s), "
+        f"{len(explicit)} carrying --targets"
+    )
+    return 0
+
+
+def mutate(workflow_path: str, job: str, mode: str, value: str) -> list[str]:
+    lines = read_lines(workflow_path)
+    ranges = {name: (start, end) for name, start, end in split_jobs(lines)}
+    if job not in ranges:
+        die(f"no job named {job} in {workflow_path}")
+    start, end = ranges[job]
+
+    if mode == "drop-job":
+        return lines[:start] + lines[end:]
+
+    if mode == "clone-without-sync":
+        # The regression this case exists to catch: a job copy-pasted from a
+        # working one, minus the steps that pin what it builds for.
+        block = [
+            line for line in lines[start:end] if SYNC not in strip_yaml_comment(line)
+        ]
+        if len(block) == end - start:
+            die(f"job {job} has no {SYNC} invocation to leave out")
+        block[0] = f"  {value}:"
+        return lines[:end] + block + lines[end:]
+
+    out = list(lines)
+    changed = 0
+    for index in range(start, end):
+        code = strip_yaml_comment(out[index])
+        if SYNC not in code:
+            continue
+        verify = "--verify-only" in code
+        if verify and mode in ("drop-targets", "retarget-sync"):
+            continue
+        if not verify and mode == "retarget-verify":
+            continue
+        if mode == "drop-targets":
+            rewritten = TARGETS.sub("", out[index]).rstrip()
+        else:
+            rewritten = TARGETS.sub(lambda _match: f"--targets \"{value}\"", out[index])
+        if rewritten != out[index]:
+            out[index] = rewritten
+            changed += 1
+
+    if changed == 0:
+        die(f"mutation {mode} changed nothing in job {job}")
+    return out
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        die(__doc__ or "usage: platform-targets.py check|mutate ...")
+
+    if argv[1] == "check":
+        if len(argv) != 4:
+            die("usage: platform-targets.py check <workflow.yml> <sync-sources.sh>")
+        return check(argv[2], argv[3])
+
+    if argv[1] == "mutate":
+        if len(argv) < 5:
+            die("usage: platform-targets.py mutate <workflow.yml> <job> <mode> [value]")
+        value = argv[5] if len(argv) > 5 else ""
+        if (argv[4].startswith("retarget") or argv[4] == "clone-without-sync") and not value:
+            die(f"mode {argv[4]} needs a value")
+        for line in mutate(argv[2], argv[3], argv[4], value):
+            print(line)
+        return 0
+
+    die(f"unknown command: {argv[1]}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+PY
+
+# --- The committed workflow satisfies every property -------------------------
+
+harness::run python3 "$CHECKER" check "$WORKFLOW" "$SYNC_SCRIPT"
+harness::assert_status 0 ".github/workflows/release.yml"
+harness::assert_output_contains "OK: " "the checker reached its success line"
+harness::assert_output_contains "carrying --targets" "every invocation is explicit"
+
+# The four values are read out of tools/sync-sources.sh, so this also pins the
+# list the workflow is being judged against: if the script stops accepting one,
+# the job map above is wrong and this fails rather than quietly narrowing.
+harness::assert_output_contains "accepted target_os" "the accepted list is reported"
+harness::assert_output_contains "android, linux, mac, win" "all four are accepted"
+harness::assert_output_contains "platform coverage: android, linux, mac, win" \
+    "every platform is covered by a job"
+
+# Read back what the checker actually saw. The floors also live in the checker,
+# where the mutants inherit them; these are the numbers a reader wants in the
+# failure output when a job is added or removed.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+found_jobs="$(grep -oE 'OK: [0-9]+ build job' "$RUN_STDOUT" | grep -oE '[0-9]+')"
+if [ "${found_jobs:-0}" -lt 5 ]; then
+    harness::fail "only ${found_jobs:-0} build job(s) found; the workflow parse is broken"
+fi
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+found_invocations="$(grep -oE '[0-9]+ tools/sync-sources.sh invocation' "$RUN_STDOUT" \
+    | grep -oE '^[0-9]+')"
+if [ "${found_invocations:-0}" -lt 10 ]; then
+    harness::fail "only ${found_invocations:-0} sync invocation(s) found; the parse is broken"
+fi
+
+# --- Mutation: the checker must reject what it exists to catch ---------------
+#
+# Without this section a checker that always exits 0 looks exactly like a
+# passing gate.
+
+# Writes a broken copy of the workflow. A mutation that changed nothing proves
+# nothing, so a no-op is a failure here rather than silent evidence.
+make_mutant() {
+    local out="$1"
+    shift
+    local status=0
+    python3 "$CHECKER" mutate "$WORKFLOW" "$@" > "$out" || status=$?
+
+    HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+    if [ "$status" -ne 0 ]; then
+        harness::fail "mutation ($*) failed: python3 exited $status"
+    fi
+
+    HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+    if cmp -s "$WORKFLOW" "$out"; then
+        harness::fail "mutation ($*) left the workflow unchanged"
+    fi
+}
+
+# A job whose sync invocation lost its --targets: back to the default target_os,
+# which is the exact regression this case exists to prevent.
+make_mutant "$tmp/no-targets.yml" android drop-targets
+harness::run python3 "$CHECKER" check "$tmp/no-targets.yml" "$SYNC_SCRIPT"
+harness::assert_nonzero_status "a sync invocation with no --targets"
+harness::assert_output_contains "job android:" "the offending job is named"
+harness::assert_output_contains "no --targets" "the reason is named"
+harness::assert_output_contains "only 9 carry --targets" "the count mismatch is reported"
+
+# A Windows job synced as linux. Both its invocations are moved together, so
+# the failure is the job/target mismatch on its own rather than a disagreement
+# between sync and verify.
+make_mutant "$tmp/wrong-target.yml" windows-x64 retarget-all linux
+harness::run python3 "$CHECKER" check "$tmp/wrong-target.yml" "$SYNC_SCRIPT"
+harness::assert_nonzero_status "a Windows job syncing with target_os linux"
+harness::assert_output_contains "job windows-x64:" "the offending job is named"
+harness::assert_output_contains 'builds windows but syncs with --targets "linux"' \
+    "the mismatch is named"
+harness::assert_output_contains 'expected "win"' "the correct value is named"
+
+# Only the --verify-only invocation is moved, so the sync/verify agreement
+# check is the one that has to fire. Proving it fires alone is what keeps it
+# from being an assertion nobody has ever seen work.
+make_mutant "$tmp/split-target.yml" linux retarget-verify mac
+harness::run python3 "$CHECKER" check "$tmp/split-target.yml" "$SYNC_SCRIPT"
+harness::assert_nonzero_status "a verify invocation naming a different target_os"
+harness::assert_output_contains "job linux:" "the offending job is named"
+harness::assert_output_contains "verify a different configuration from the one synced" \
+    "the agreement check is what fired"
+
+# A build job copy-pasted from a working one, minus the sync steps. Coverage
+# and both floors are still satisfied, so the only thing left to notice it is
+# the requirement that a job which builds must also sync and verify.
+make_mutant "$tmp/copy-pasted-job.yml" macos clone-without-sync macos-copy
+harness::run python3 "$CHECKER" check "$tmp/copy-pasted-job.yml" "$SYNC_SCRIPT"
+harness::assert_nonzero_status "a build job that never synchronises at all"
+harness::assert_output_contains \
+    "job macos-copy: builds macos but never invokes tools/sync-sources.sh" \
+    "the job that never syncs is named"
+harness::assert_output_contains "never invokes tools/sync-sources.sh --verify-only" \
+    "the missing verification is named"
+
+# A whole platform dropped. The coverage assertion and both vacuity floors are
+# the only things standing between this and a green run.
+make_mutant "$tmp/dropped-job.yml" android drop-job
+harness::run python3 "$CHECKER" check "$tmp/dropped-job.yml" "$SYNC_SCRIPT"
+harness::assert_nonzero_status "a workflow that stopped building a platform"
+harness::assert_output_contains "no build job syncs with target_os android" \
+    "the dropped platform is named"
+harness::assert_output_contains "vacuity floor: found 4 build job(s)" "the job floor fires"
+harness::assert_output_contains "vacuity floor: found 8" "the invocation floor fires"
+
+harness::pass

--- a/tools/tests/cases/sync-enforces-locked-revisions.sh
+++ b/tools/tests/cases/sync-enforces-locked-revisions.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# The sync command must produce exactly the revisions the lock declares, and
+# `--verify-only` must reject anything else.
+#
+# This is the check a stale self-hosted runner has to fail. The previous CI did
+# `if [ ! -d chromium/src/.git ]; then fetch; else echo "cached, skipping"; fi`,
+# so a runner that had ever fetched Chromium compiled whatever commit it
+# happened to hold, forever, with nothing validating it.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+SYNC="$ASTRO_ROOT/tools/sync-sources.sh"
+tmp="$(harness::tmpdir)"
+
+# --- Fixture origins ---------------------------------------------------------
+
+origins="$tmp/origins"
+mkdir -p "$origins"
+
+mapfile -t CHROMIUM_SHAS < <(harness::make_source_repo "$origins/chromium" chromium sentinels)
+CHROMIUM_TIP="${CHROMIUM_SHAS[2]}"
+CHROMIUM_OLD="${CHROMIUM_SHAS[0]}"
+
+mapfile -t DEPOT_SHAS < <(harness::make_source_repo "$origins/depot_tools" depot_tools)
+DEPOT_TIP="${DEPOT_SHAS[2]}"
+
+mapfile -t UNGOOGLED_SHAS < <(harness::make_source_repo "$origins/ungoogled" ungoogled)
+UNGOOGLED_TIP="${UNGOOGLED_SHAS[2]}"
+
+lock="$tmp/browser.lock.json"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$tmp/browser.lock.schema.json"
+harness::write_lock "$lock" \
+    "file://$origins/chromium" "$CHROMIUM_TIP" \
+    "file://$origins/depot_tools" "$DEPOT_TIP" \
+    "file://$origins/ungoogled" "$UNGOOGLED_TIP"
+
+work="$tmp/work"
+mkdir -p "$work/chromium"
+
+run_sync() {
+    harness::run env ASTRO_CHROMIUM_SRC="$work/chromium/src" \
+        "$SYNC" --no-deps --lock "$lock" \
+        --chromium-src "$work/chromium/src" \
+        --depot-tools "$work/depot_tools" \
+        --ungoogled "$work/ungoogled" "$@"
+}
+
+# --- Bootstrap ---------------------------------------------------------------
+
+run_sync
+harness::assert_status 0 "bootstrap sync from empty"
+harness::assert_output_contains "$CHROMIUM_TIP" "reports the chromium revision"
+harness::assert_output_contains "$DEPOT_TIP" "reports the depot_tools revision"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 3))
+[ "$(git -C "$work/chromium/src" rev-parse HEAD)" = "$CHROMIUM_TIP" ] \
+    || harness::fail "chromium is not at the locked commit"
+[ "$(git -C "$work/depot_tools" rev-parse HEAD)" = "$DEPOT_TIP" ] \
+    || harness::fail "depot_tools is not at the locked commit"
+[ "$(git -C "$work/ungoogled" rev-parse HEAD)" = "$UNGOOGLED_TIP" ] \
+    || harness::fail "ungoogled is not at the locked commit"
+
+# The checkout must be DETACHED. A branch can be advanced afterwards and
+# nothing would notice; that is how a pinned build silently stops being pinned.
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if git -C "$work/chromium/src" symbolic-ref --quiet HEAD >/dev/null; then
+    harness::fail "chromium checkout is on a branch, not detached"
+fi
+
+# .gclient is rendered from the committed template.
+harness::assert_file_exists "$work/chromium/.gclient"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+grep -q 'managed.*False' "$work/chromium/.gclient" \
+    || harness::fail ".gclient does not carry managed = False"
+
+# --- Idempotence -------------------------------------------------------------
+
+run_sync
+first="$(cat "$RUN_STDOUT")"
+harness::assert_status 0 "second sync"
+harness::assert_output_contains "already at $CHROMIUM_TIP" "second run does no work"
+
+run_sync
+second="$(cat "$RUN_STDOUT")"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+if [ "$first" != "$second" ]; then
+    printf -- '--- first ---\n%s\n--- second ---\n%s\n' "$first" "$second" >&2
+    harness::fail "two consecutive syncs produced different revision output"
+fi
+
+# --- --verify-only accepts a correct tree ------------------------------------
+
+run_sync --verify-only
+harness::assert_status 0 "verify-only against a correct tree"
+harness::assert_output_contains "VERIFY ONLY" "mode banner"
+
+# --- The stale-runner case: wrong commit -------------------------------------
+
+git -C "$work/chromium/src" checkout --quiet --detach "$CHROMIUM_OLD"
+
+run_sync --verify-only
+harness::assert_nonzero_status "verify-only against a checkout at the wrong commit"
+harness::assert_output_contains "wrong commit" "refusal reason"
+harness::assert_output_contains "$CHROMIUM_OLD" "names the commit found"
+harness::assert_output_contains "$CHROMIUM_TIP" "names the commit locked"
+harness::assert_output_contains "stale self-hosted runner" "explains what it is guarding"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+[ "$(git -C "$work/chromium/src" rev-parse HEAD)" = "$CHROMIUM_OLD" ] \
+    || harness::fail "--verify-only modified the checkout"
+
+# Default mode corrects it.
+run_sync
+harness::assert_status 0 "default mode corrects a wrong commit"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+[ "$(git -C "$work/chromium/src" rev-parse HEAD)" = "$CHROMIUM_TIP" ] \
+    || harness::fail "sync did not correct the checkout"
+
+# --- A moving remote branch cannot change a locked build ---------------------
+
+printf 'upstream moved on\n' > "$origins/chromium/content.txt"
+git -C "$origins/chromium" add -A
+git -C "$origins/chromium" commit --quiet -m "upstream advances main"
+MOVED="$(git -C "$origins/chromium" rev-parse HEAD)"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+[ "$MOVED" != "$CHROMIUM_TIP" ] || harness::fail "premise broken: the branch did not move"
+
+run_sync
+harness::assert_status 0 "sync after the remote branch advanced"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 2))
+[ "$(git -C "$work/chromium/src" rev-parse HEAD)" = "$CHROMIUM_TIP" ] \
+    || harness::fail "a moving remote branch changed the locked build"
+[ "$(git -C "$work/chromium/src" rev-parse HEAD)" != "$MOVED" ] \
+    || harness::fail "the checkout followed the remote branch"
+
+harness::pass

--- a/tools/tests/cases/sync-rejects-stale-and-dirty-checkouts.sh
+++ b/tools/tests/cases/sync-rejects-stale-and-dirty-checkouts.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# A cached self-hosted runner accumulates state: leftover branches, rejected
+# patch files, half-reverted edits. None of it is visible in a commit SHA, and
+# all of it changes what gets compiled.
+#
+# The previous CI treated the cache as source-of-truth state — it skipped
+# synchronization entirely whenever `chromium/src/.git` existed — so every one
+# of these survived indefinitely and silently.
+
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/harness.sh"
+harness::setup
+
+SYNC="$ASTRO_ROOT/tools/sync-sources.sh"
+tmp="$(harness::tmpdir)"
+
+origins="$tmp/origins"
+mkdir -p "$origins"
+mapfile -t CHROMIUM_SHAS < <(harness::make_source_repo "$origins/chromium" chromium sentinels)
+CHROMIUM_TIP="${CHROMIUM_SHAS[2]}"
+mapfile -t DEPOT_SHAS < <(harness::make_source_repo "$origins/depot_tools" depot_tools)
+mapfile -t UNGOOGLED_SHAS < <(harness::make_source_repo "$origins/ungoogled" ungoogled)
+
+lock="$tmp/browser.lock.json"
+cp "$ASTRO_ROOT/browser.lock.schema.json" "$tmp/browser.lock.schema.json"
+harness::write_lock "$lock" \
+    "file://$origins/chromium" "$CHROMIUM_TIP" \
+    "file://$origins/depot_tools" "${DEPOT_SHAS[2]}" \
+    "file://$origins/ungoogled" "${UNGOOGLED_SHAS[2]}"
+
+work="$tmp/work"
+mkdir -p "$work/chromium"
+
+run_sync() {
+    harness::run env ASTRO_CHROMIUM_SRC="$work/chromium/src" \
+        "$SYNC" --no-deps --lock "$lock" \
+        --chromium-src "$work/chromium/src" \
+        --depot-tools "$work/depot_tools" \
+        --ungoogled "$work/ungoogled" "$@"
+}
+
+run_sync
+harness::assert_status 0 "initial sync"
+
+src="$work/chromium/src"
+
+# --- Uncommitted developer work --------------------------------------------
+
+printf 'work in progress\n' > "$src/developer_scratch.cc"
+printf 'edited\n' >> "$src/content.txt"
+
+run_sync
+harness::assert_nonzero_status "checkout carrying local changes"
+harness::assert_output_contains "uncommitted change" "refusal names the state"
+harness::assert_output_contains "preserves developer work" "explains the policy"
+harness::assert_output_contains "ASTRO_ALLOW_DIRTY_CHROMIUM=1" "names the override"
+
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 2))
+grep -q 'work in progress' "$src/developer_scratch.cc" \
+    || harness::fail "developer's file was modified"
+grep -q 'edited' "$src/content.txt" \
+    || harness::fail "developer's edit was discarded"
+
+# The override must NOT apply to --verify-only: a CI gate that can be waved
+# through by an environment variable is not a gate.
+harness::run env ASTRO_CHROMIUM_SRC="$src" ASTRO_ALLOW_DIRTY_CHROMIUM=1 \
+    "$SYNC" --no-deps --verify-only --lock "$lock" \
+    --chromium-src "$src" --depot-tools "$work/depot_tools" --ungoogled "$work/ungoogled"
+harness::assert_nonzero_status "verify-only must ignore the dirty override"
+harness::assert_output_contains "uncommitted change" "still reports the dirty state"
+
+# In default mode the override is honoured.
+harness::run env ASTRO_CHROMIUM_SRC="$src" ASTRO_ALLOW_DIRTY_CHROMIUM=1 \
+    "$SYNC" --no-deps --lock "$lock" \
+    --chromium-src "$src" --depot-tools "$work/depot_tools" --ungoogled "$work/ungoogled"
+harness::assert_status 0 "explicit developer override in default mode"
+harness::assert_output_contains "override:dirty-chromium" "structured override warning"
+
+rm -f "$src/developer_scratch.cc"
+git -C "$src" checkout --quiet -- content.txt
+
+# --- Leftover patch artifacts ------------------------------------------------
+
+printf '***rejected hunk***\n' > "$src/some_file.cc.rej"
+
+run_sync
+harness::assert_nonzero_status "checkout carrying a .rej artifact"
+harness::assert_output_contains "leftover patch artifacts" "refusal names the artifacts"
+harness::assert_output_contains "some_file.cc.rej" "names the artifact"
+
+rm -f "$src/some_file.cc.rej"
+
+# --- Leftover branch ---------------------------------------------------------
+#
+# The old fetch created `astro-<version>` as a BRANCH. A runner that ran it
+# once keeps that branch forever, and a checkout sitting on it is not pinned.
+
+git -C "$src" checkout --quiet -b astro-146.0.7680.177
+
+harness::run env ASTRO_CHROMIUM_SRC="$src" \
+    "$SYNC" --no-deps --verify-only --lock "$lock" \
+    --chromium-src "$src" --depot-tools "$work/depot_tools" --ungoogled "$work/ungoogled"
+harness::assert_nonzero_status "verify-only against a checkout on a branch"
+harness::assert_output_contains "not detached" "refusal reason"
+harness::assert_output_contains "astro-146.0.7680.177" "names the branch"
+
+# Default mode detaches it.
+run_sync
+harness::assert_status 0 "default mode detaches a branch checkout"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 2))
+if git -C "$src" symbolic-ref --quiet HEAD >/dev/null; then
+    harness::fail "checkout is still on a branch after sync"
+fi
+[ "$(git -C "$src" rev-parse HEAD)" = "$CHROMIUM_TIP" ] \
+    || harness::fail "checkout is not at the locked commit"
+
+# --- --dry-run changes nothing ----------------------------------------------
+
+git -C "$src" checkout --quiet --detach "${CHROMIUM_SHAS[0]}"
+before="$(harness::manifest "$src")"
+
+run_sync --dry-run
+harness::assert_status 0 "dry run against a wrong-commit checkout"
+harness::assert_output_contains "PLAN" "prints the plan"
+harness::assert_tree_unchanged "$src" "$before"
+HARNESS_ASSERTIONS=$((HARNESS_ASSERTIONS + 1))
+[ "$(git -C "$src" rev-parse HEAD)" = "${CHROMIUM_SHAS[0]}" ] \
+    || harness::fail "dry run moved the checkout"
+
+harness::pass

--- a/tools/tests/lib/scan-shell-patterns.py
+++ b/tools/tests/lib/scan-shell-patterns.py
@@ -11,9 +11,17 @@ patterns they removed — an error message that names `2>/dev/null` as the thing
 that hid a defect must not itself trip the check. A naive grep cannot tell the
 difference, and a check that cries wolf is a check somebody disables.
 
-A genuine, reviewed exception carries an inline marker on the offending line:
+A genuine, reviewed exception carries a marker naming the ONE rule it
+suppresses, plus a justification, in a REAL comment:
 
-    rsync -a --delete "$BUILD_DIR/" "$INSTALL_DIR/"   # astro-allow: reason
+    rsync -a --delete "$SRC/" "$DEST/"   # astro-allow:rsync-delete reason here
+
+The marker must be a comment (not a string literal, not executable code), must
+sit on the offending line or on a pure-comment line directly above it, must
+name a known rule id, and must justify itself. Every one of those conditions is
+load-bearing: the marker used to be a bare substring test against the raw line,
+so `echo "astro-allow: hi"` on the line above a banned command disabled the
+whole check, and a single unqualified marker switched off every rule at once.
 
 Usage:
     scan-shell-patterns.py FILE [FILE...]
@@ -28,6 +36,11 @@ import re
 import sys
 
 ALLOW_MARKER = "astro-allow:"
+
+# A justification floor. The point of an exception is that a reviewer reads a
+# reason, so "astro-allow:rsync-delete x" is not one. Short enough that every
+# genuine reason in this repository clears it comfortably.
+MIN_JUSTIFICATION_CHARS = 8
 
 RULES: list[tuple[str, re.Pattern[str], str]] = [
     (
@@ -48,7 +61,7 @@ RULES: list[tuple[str, re.Pattern[str], str]] = [
     ),
     (
         "suppressed-failure",
-        re.compile(r"\|\|\s*(?:true|:)\s*(?:$|;|&)"),
+        re.compile(r"\|\|\s*(?:true|:)\s*(?:$|[;&)`])"),
         "a swallowed failure; classify the step with astro::optional instead",
     ),
     (
@@ -57,6 +70,49 @@ RULES: list[tuple[str, re.Pattern[str], str]] = [
         "discarded stderr hides the reason a required step failed",
     ),
 ]
+
+# Applies to shell scripts AND to CI workflow files (ASTRO-NEXT-002, issue #5).
+SOURCE_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "unconstrained-pull",
+        re.compile(r"\bgit\s+(-C\s+\S+\s+)?pull\b"),
+        "`git pull` takes whatever the remote's branch points at now; a build "
+        "dependency must be checked out at a locked commit instead",
+    ),
+]
+
+# Applies to CI workflow files ONLY, and the distinction is principled rather
+# than a concession to false positives.
+#
+# tools/sync-sources.sh legitimately tests whether a checkout exists, because
+# bootstrapping one is its job. A CI job has no such licence: it must invoke
+# the sync command unconditionally and let that command decide. A workflow that
+# branches on `.git` existence is deciding for itself whether to synchronise,
+# which is precisely how a self-hosted runner ends up compiling whatever commit
+# it happens to hold.
+WORKFLOW_RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "mutable-action-tag",
+        re.compile(r"uses:\s*[A-Za-z0-9._-]+/[A-Za-z0-9._/-]+@(?![0-9a-f]{40}\b)\S+"),
+        "a GitHub Action referenced by tag or branch instead of a full commit "
+        "SHA lets upstream tag movement or a supply-chain compromise change what "
+        "CI executes with no diff in this repository",
+    ),
+    (
+        "cache-as-source-of-truth",
+        re.compile(r"-d\s+[\"']?[^\"'\s]*\.git[\"']?\s*\]"),
+        "a CI job deciding whether to synchronise by testing for an existing "
+        ".git treats a cache as source-of-truth state, so a stale runner keeps "
+        "compiling whatever commit it happens to hold",
+    ),
+]
+
+# Derived from the tables rather than written out again, so a new rule becomes
+# markable automatically and a typo in a marker cannot name a rule that does
+# not exist.
+ALL_RULE_IDS = frozenset(
+    name for name, _pattern, _reason in RULES + SOURCE_RULES + WORKFLOW_RULES
+)
 
 HEREDOC_START = re.compile(r"<<-?\s*(['\"]?)([A-Za-z_][A-Za-z0-9_]*)\1")
 
@@ -68,12 +124,43 @@ PROBE = re.compile(r"\bcommand\s+-v\b")
 
 
 def strip_noncode(line: str) -> str:
-    """Return the line with quoted literals and the trailing comment removed."""
+    """Return the line with quoted literals and the trailing comment removed.
+
+    Command substitutions are kept as CODE even inside a double-quoted string,
+    and quoting restarts within them. Without that, a line like
+
+        branch="$(git symbolic-ref --short HEAD || true)"
+
+    reads as one quoted literal — the inner `"` closes the outer one — and the
+    `|| true` inside it disappears from the scan. That is a false negative, the
+    dangerous direction for this check, and it was found in real code here.
+
+    Nesting is tracked with a stack, so `"$(f "$(g)" || true)"` behaves too.
+    """
     out: list[str] = []
     quote: str | None = None
+    # Each entry is the quoting state to restore when a `$(` is closed.
+    substitution_stack: list[str | None] = []
     index = 0
+
     while index < len(line):
         char = line[index]
+
+        # A `$(` opens code, whatever the surrounding quoting — except inside
+        # single quotes, where nothing expands.
+        if quote != "'" and line.startswith("$(", index):
+            substitution_stack.append(quote)
+            quote = None
+            out.append(" ")
+            index += 2
+            continue
+
+        if substitution_stack and quote is None and char == ")":
+            quote = substitution_stack.pop()
+            out.append(" ")
+            index += 1
+            continue
+
         if quote:
             if char == "\\" and quote == '"':
                 index += 2
@@ -82,64 +169,283 @@ def strip_noncode(line: str) -> str:
                 quote = None
             index += 1
             continue
+
         if char in ("'", '"'):
             quote = char
             out.append(" ")
             index += 1
             continue
+
         if char == "#":
-            # A '#' only starts a comment at the start of a word.
-            if not out or out[-1].isspace():
+            # A '#' only starts a comment at the start of a word, and never
+            # inside a command substitution.
+            if not substitution_stack and (not out or out[-1].isspace()):
                 break
             out.append(char)
             index += 1
             continue
+
         if char == "\\":
             out.append(" ")
             index += 2
             continue
+
         out.append(char)
         index += 1
+
     return "".join(out)
 
 
-def scan(path: str) -> list[tuple[int, str, str]]:
+def comment_start(line: str, *, escapes: bool) -> int | None:
+    """Index at which a real comment begins, or None if the line has none.
+
+    Quoting is respected, so a `#` inside a string literal is not a comment.
+    That is what stops `echo "# astro-allow:rsync-delete ..."` from reading as
+    a reviewed exception. `escapes` selects the shell reading of a backslash
+    inside double quotes; YAML has no equivalent here.
+
+    Deliberately reports the POSITION rather than the stripped line: both the
+    strippers below and the marker reader need the same scan, and the marker
+    reader needs the half the strippers throw away.
+    """
+    index, _quote = _scan_quotes(line, escapes=escapes)
+    return index
+
+
+def _scan_quotes(line: str, *, escapes: bool) -> tuple[int | None, str | None]:
+    """(comment index, quote still open at the end) for one physical line.
+
+    One scan answers both questions, and they are answered together on purpose:
+    a comment can only begin OUTSIDE a string, so the two states are the same
+    state read at different moments.
+    """
+    quote: str | None = None
+    for index, char in enumerate(line):
+        if quote:
+            if escapes and char == "\\" and quote == '"':
+                continue
+            if char == quote:
+                quote = None
+            continue
+        if char in ("'", '"'):
+            quote = char
+            continue
+        if char == "#" and (index == 0 or line[index - 1].isspace()):
+            # A comment runs to the newline, so nothing after it can leave a
+            # quote open.
+            return index, None
+    return None, quote
+
+
+def quote_open_at_end(text: str, *, escapes: bool) -> bool:
+    """True when `text` ends inside an unterminated string.
+
+    A quote continues a logical line with no backslash involved, and until this
+    existed that shape hid everything after it exactly as the backslash shape
+    did:
+
+        astro::info "a message spanning
+        two lines with no backslash" && rm -f /tmp/x || true
+
+    reported nothing. Joining on a backslash alone closes one instance of the
+    defect; joining on either closes the class.
+    """
+    _index, quote = _scan_quotes(text, escapes=escapes)
+    return quote is not None
+
+
+def strip_comments_only(line: str) -> str:
+    """Drop a trailing shell comment but KEEP string contents.
+
+    The source-pinning rules match paths and arguments that are normally
+    quoted — `[ ! -d "chromium/src/.git" ]`, for instance. strip_noncode
+    removes quoted text, so those rules would never fire on real code while
+    still firing on the prose in a comment: exactly backwards.
+
+    Comments are still removed, which is what keeps a script's own description
+    of the shape it removed from tripping the check.
+    """
+    index = comment_start(line, escapes=True)
+    return line if index is None else line[:index]
+
+
+def strip_yaml_noncode(line: str) -> str:
+    """Drop a YAML comment. Workflow files embed shell in `run:` blocks, so the
+    shell rules apply, but the shell tokenizer's heredoc and quoting rules do
+    not map onto YAML block scalars."""
+    index = comment_start(line, escapes=False)
+    return line if index is None else line[:index]
+
+
+def comment_text(line: str, *, escapes: bool) -> str:
+    """The comment part of a line, or "" when the line carries no comment."""
+    index = comment_start(line, escapes=escapes)
+    return "" if index is None else line[index:]
+
+
+def is_pure_comment_line(line: str) -> bool:
+    """True when the line is nothing but a comment.
+
+    A marker on the line ABOVE only counts when that line carries no code, so
+    that an executable line cannot hand an exception to its neighbour.
+    """
+    return line.lstrip().startswith("#")
+
+
+def parse_allow_markers(comment: str) -> tuple[set[str], list[str]]:
+    """Read `astro-allow:<rule-id> <justification>` markers out of a comment.
+
+    Returns the rule ids granted and, separately, complaints about markers that
+    look like exceptions but are not honoured. A marker grants exactly the rule
+    it names — never every rule on the line — and only when it justifies
+    itself, so neither a bare marker nor one naming some other rule can wave a
+    finding through.
+    """
+    granted: set[str] = set()
+    complaints: list[str] = []
+
+    # Splitting on the marker bounds each justification at the next marker, so
+    # a line violating two rules can carry one marker per rule.
+    for segment in comment.split(ALLOW_MARKER)[1:]:
+        words = segment.split(None, 1)
+        if not words:
+            complaints.append("marker names no rule id")
+            continue
+
+        rule = words[0]
+        justification = words[1].strip() if len(words) > 1 else ""
+
+        if rule not in ALL_RULE_IDS:
+            complaints.append(f"marker names unknown rule {rule!r}")
+        elif len(justification) < MIN_JUSTIFICATION_CHARS or not any(
+            char.isalpha() for char in justification
+        ):
+            complaints.append(f"marker for {rule} carries no justification")
+        else:
+            granted.add(rule)
+
+    return granted, complaints
+
+
+def continues_onto_next_line(text: str, *, escapes: bool) -> bool:
+    """True when this text continues onto the following physical line.
+
+    Scanning physical lines was a bypass needing no marker at all. A string
+    opened on one physical line and closed on the next left the closing quote
+    reading as an OPENING one, so everything after it — `|| true` included —
+    counted as quoted text and was never scanned:
+
+        astro::info "a message that spans \\
+            two physical lines" && rm -f /tmp/x || true
+
+    reported nothing. Any banned pattern on a continued logical line was
+    invisible, which disarmed the epic's central rule silently and for free.
+
+    Two shapes are NOT continuations, and both are tested:
+      * a trailing backslash inside a COMMENT is ordinary text — a comment ends
+        at the newline and cannot be continued;
+      * an ESCAPED backslash (`\\\\`) ends the line, so trailing backslashes are
+        counted and only an odd number continues.
+    """
+    index = comment_start(text, escapes=escapes)
+    code = text if index is None else text[:index]
+    if not code.endswith("\\"):
+        return False
+    return (len(code) - len(code.rstrip("\\"))) % 2 == 1
+
+
+def scan(path: str) -> tuple[list[tuple[int, str, str]], list[tuple[int, str]]]:
     violations: list[tuple[int, str, str]] = []
+    notes: list[tuple[int, str]] = []
     heredoc_terminator: str | None = None
-    previous = ""
+    # Rule ids a marker on the PREVIOUS line granted to this one.
+    inherited: set[str] = set()
+    is_workflow = path.endswith((".yml", ".yaml"))
+    rules = (SOURCE_RULES + WORKFLOW_RULES) if is_workflow else RULES + SOURCE_RULES
+    source_rule_names = {name for name, _p, _r in SOURCE_RULES}
 
     with open(path, encoding="utf-8") as handle:
-        for number, raw in enumerate(handle, start=1):
-            raw = raw.rstrip("\n")
-            # The marker is accepted on the offending line or the one directly
-            # above it, so a real justification can be written as a comment
-            # block rather than crammed into a trailing comment.
-            allowed = ALLOW_MARKER in raw or ALLOW_MARKER in previous
-            previous = raw
+        physical = [line.rstrip("\n") for line in handle]
 
-            if heredoc_terminator is not None:
-                if raw.strip() == heredoc_terminator:
-                    heredoc_terminator = None
-                continue
+    # Physical lines are walked by index rather than iterated, because a
+    # logical line consumes an unbounded number of them and a heredoc body is
+    # consumed physically regardless of any backslash inside it.
+    position = 0
+    while position < len(physical):
+        number = position + 1
+        raw = physical[position]
 
+        if not is_workflow and heredoc_terminator is not None:
+            if raw.strip() == heredoc_terminator:
+                heredoc_terminator = None
+            # A heredoc body is data. It never grants an exception to the line
+            # that follows it, and a backslash in it continues nothing.
+            inherited = set()
+            position += 1
+            continue
+
+        # Join continuations into one logical line. The accumulated text is
+        # what decides whether to keep going, so quote state carries across the
+        # join — which is the entire point.
+        first_number = number
+        while position + 1 < len(physical):
+            if continues_onto_next_line(raw, escapes=not is_workflow):
+                # Shell removes the backslash-newline entirely, so the two
+                # halves are glued with nothing between them.
+                position += 1
+                raw = raw[: raw.rindex("\\")] + physical[position]
+            elif quote_open_at_end(raw, escapes=not is_workflow):
+                # A newline inside a string is content, not a separator; a
+                # space keeps the joined text on one line so the rules' `$`
+                # anchors mean what they mean everywhere else.
+                position += 1
+                raw = raw + " " + physical[position]
+            else:
+                break
+
+        number = first_number
+        # `raw` is now the logical line; everything below reads it unchanged.
+        position += 1
+
+        if is_workflow:
+            code = strip_yaml_noncode(raw)
+            source_code = code
+        else:
             code = strip_noncode(raw)
+            source_code = strip_comments_only(raw)
 
-            if not allowed:
-                for rule, pattern, _reason in RULES:
-                    if rule == "suppressed-stderr" and PROBE.search(code):
-                        continue
-                    if pattern.search(code):
-                        violations.append((number, rule, raw.strip()))
+        # An exception must be a real comment. Reading the marker out of the
+        # comment rather than the raw line is the whole fix: a string literal
+        # or an executable line mentioning it grants nothing.
+        granted, complaints = parse_allow_markers(
+            comment_text(raw, escapes=not is_workflow)
+        )
+        notes.extend((number, complaint) for complaint in complaints)
 
-            # Matched against the RAW line: the terminator is usually quoted
-            # (`<< 'EOF'`), and strip_noncode removes quoted text, so scanning
-            # the stripped line never sees a heredoc start and every generated
-            # script body gets scanned as if it were this script's own code.
+        allowed = granted | inherited
+        for rule, pattern, _reason in rules:
+            if rule in allowed:
+                continue
+            if rule == "suppressed-stderr" and PROBE.search(code):
+                continue
+            target = source_code if rule in source_rule_names else code
+            if pattern.search(target):
+                violations.append((number, rule, raw.strip()))
+
+        # A marker is inherited by the next line only from a pure comment
+        # line, so the association stays immediate and unambiguous.
+        inherited = granted if is_pure_comment_line(raw) else set()
+
+        # Matched against the RAW line: the terminator is usually quoted
+        # (`<< 'EOF'`), and strip_noncode removes quoted text, so scanning
+        # the stripped line never sees a heredoc start and every generated
+        # script body gets scanned as if it were this script's own code.
+        if not is_workflow:
             match = HEREDOC_START.search(raw)
             if match:
                 heredoc_terminator = match.group(2)
 
-    return violations
+    return violations, notes
 
 
 def main(argv: list[str]) -> int:
@@ -150,17 +456,25 @@ def main(argv: list[str]) -> int:
 
     total = 0
     for path in paths:
-        for number, rule, text in scan(path):
+        violations, notes = scan(path)
+        for number, rule, text in violations:
             print(f"{path}:{number}: {rule}: {text}")
             total += 1
+        # A marker that looks like an exception and is not honoured is the one
+        # state a developer cannot diagnose from the finding alone, so say so.
+        for number, note in notes:
+            print(f"{path}:{number}: ignored {note}", file=sys.stderr)
 
     if total:
         print(f"\n{total} banned pattern(s) found.", file=sys.stderr)
         print("Reasons:", file=sys.stderr)
-        for rule, _pattern, reason in RULES:
+        for rule, _pattern, reason in RULES + SOURCE_RULES + WORKFLOW_RULES:
             print(f"  {rule}: {reason}", file=sys.stderr)
         print(
-            f"\nA reviewed exception carries an inline '# {ALLOW_MARKER} reason' marker.",
+            f"\nA reviewed exception is a COMMENT reading "
+            f"'# {ALLOW_MARKER}<rule-id> <justification>', on the offending line "
+            f"or on a pure-comment line directly above it. It suppresses only "
+            f"the rule it names. Rule ids: {', '.join(sorted(ALL_RULE_IDS))}.",
             file=sys.stderr,
         )
         return 1

--- a/tools/update-chromium.sh
+++ b/tools/update-chromium.sh
@@ -1,41 +1,202 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# update-chromium.sh — propose a Chromium revision update.
+#
+# Resolves a requested version to an exact commit at the origin, verifies the
+# tag/commit relationship is consistent, updates browser.lock.json, and writes
+# a change report. It never falls back to a nearby version.
+#
+# What it replaces (ASTRO-NEXT-002, issue #5): a script that exported
+# CHROMIUM_VERSION and re-ran the fetch/sync/patch chain, in which
+# sync-ungoogled.sh would silently accept a tag for a DIFFERENT Chromium major
+# — or master — when the exact one did not exist. A "successful" update could
+# therefore build against a patch set written for another browser version.
+#
+# Usage:
+#   tools/update-chromium.sh <version>          Propose the update.
+#   tools/update-chromium.sh <version> --apply  Also sync sources to it.
+#
+# The default is deliberately proposal-only: an update changes what the whole
+# project compiles, so it lands as a reviewable lock diff plus a report, not as
+# a side effect of running a script.
 
-ASTRO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ASTRO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export ASTRO_ROOT
+# shellcheck source=tools/lib/astro-common.sh
+source "$ASTRO_ROOT/tools/lib/astro-common.sh"
 
-echo "=== Chromium Version Update ==="
-echo ""
-echo "This script updates Astro to a new Chromium version."
-echo "It will:"
-echo "  1. Fetch the new Chromium version"
-echo "  2. Sync matching ungoogled-chromium patches"
-echo "  3. Attempt to apply all patches"
-echo "  4. Report any conflicts"
-echo ""
+LOCK_FILE="$ASTRO_ROOT/browser.lock.json"
+LOCK="$ASTRO_ROOT/tools/lib/lock.py"
+NEW_VERSION=""
+APPLY=0
 
-NEW_VERSION="${1:-}"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --apply) APPLY=1 ;;
+        --lock)  shift; LOCK_FILE="${1:?--lock needs a file}" ;;
+        -h|--help)
+            printf 'Usage: %s <chromium-version> [--apply]\n' "$0" >&2
+            printf 'Example: %s 147.0.7710.20\n' "$0" >&2
+            exit 0
+            ;;
+        -*) astro::die "Unknown argument: $1" ;;
+        *)  NEW_VERSION="$1" ;;
+    esac
+    shift
+done
+
 if [ -z "$NEW_VERSION" ]; then
-    echo "Usage: $0 <chromium-version>"
-    echo "Example: $0 136.0.7103.92"
-    exit 1
+    astro::die_with_hint \
+        "No Chromium version given." \
+        "Usage: tools/update-chromium.sh <chromium-version> [--apply]" \
+        "Example: tools/update-chromium.sh 147.0.7710.20"
 fi
 
-export CHROMIUM_VERSION="$NEW_VERSION"
+if ! printf '%s' "$NEW_VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+    astro::die_with_hint \
+        "'$NEW_VERSION' is not a Chromium version." \
+        "Expected four dot-separated numbers, e.g. 147.0.7710.20." \
+        "A branch name or a partial version is not accepted: the update must" \
+        "resolve to exactly one commit."
+fi
 
-echo ">>> Updating to Chromium $NEW_VERSION..."
-echo ""
+astro::require_cmd git python3
+astro::require_file "$LOCK_FILE" "lock file"
 
-# Step 1: Fetch new Chromium version
-"$ASTRO_ROOT/tools/fetch-chromium.sh"
+python3 "$LOCK" --validate "$LOCK_FILE" >&2
 
-# Step 2: Sync ungoogled patches
-"$ASTRO_ROOT/tools/sync-ungoogled.sh"
+CURRENT_VERSION="$(python3 "$LOCK" --get chromium.version "$LOCK_FILE")"
+CURRENT_COMMIT="$(python3 "$LOCK" --get chromium.commit "$LOCK_FILE")"
+CHROMIUM_URL="$(python3 "$LOCK" --get chromium.url "$LOCK_FILE")"
 
-# Step 3: Apply patches
-echo ""
-echo ">>> Applying patches to new version..."
-"$ASTRO_ROOT/tools/apply-patches.sh" all
+astro::info "=== Chromium revision update ==="
+astro::info "  current: $CURRENT_VERSION ($CURRENT_COMMIT)"
+astro::info "  proposed: $NEW_VERSION"
 
-echo ""
-echo "=== Update to Chromium $NEW_VERSION complete ==="
-echo "Run tools/build.sh to build."
+if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
+    astro::info "Already locked to $NEW_VERSION. Nothing to propose."
+    exit 0
+fi
+
+# --------------------------------------------------------------------------
+# Resolve the version to exactly one commit, or fail
+# --------------------------------------------------------------------------
+
+NEW_REF="refs/tags/$NEW_VERSION"
+astro::info ">>> Resolving $NEW_REF at $CHROMIUM_URL"
+
+LS_REMOTE="$(git ls-remote "$CHROMIUM_URL" "$NEW_REF" "$NEW_REF^{}")"
+
+if [ -z "$LS_REMOTE" ]; then
+    astro::die_with_hint \
+        "Chromium $NEW_VERSION does not exist at $CHROMIUM_URL" \
+        "" \
+        "No nearby version is substituted. The previous implementation would" \
+        "have fallen back to the newest tag sharing a major version, or to" \
+        "master, and reported success — so a build could silently target a" \
+        "different browser than the one requested." \
+        "" \
+        "Check the version at https://chromiumdash.appspot.com/releases"
+fi
+
+# An annotated tag advertises both the tag object and, as `^{}`, the commit it
+# points at. The peeled value is the commit; comparing the unpeeled one gives a
+# tag object SHA, which is not what any checkout would land on.
+NEW_COMMIT="$(printf '%s\n' "$LS_REMOTE" | awk -v ref="$NEW_REF^{}" '$2 == ref {print $1}')"
+TAG_OBJECT="$(printf '%s\n' "$LS_REMOTE" | awk -v ref="$NEW_REF" '$2 == ref {print $1}')"
+
+if [ -z "$NEW_COMMIT" ]; then
+    NEW_COMMIT="$TAG_OBJECT"
+fi
+
+if [ -z "$NEW_COMMIT" ]; then
+    astro::die "Could not resolve $NEW_REF to a commit at $CHROMIUM_URL"
+fi
+
+if ! printf '%s' "$NEW_COMMIT" | grep -qE '^[0-9a-f]{40}$'; then
+    astro::die "Resolved '$NEW_COMMIT' for $NEW_REF, which is not a commit SHA"
+fi
+
+# The tag/commit relationship must be internally consistent: an annotated tag
+# whose peeled value is missing, or a ref advertising two different commits,
+# means the remote is in a state no build should be pinned against.
+COMMIT_COUNT="$(printf '%s\n' "$LS_REMOTE" | awk '{print $1}' | sort -u | wc -l | tr -d '[:space:]')"
+if [ -n "$TAG_OBJECT" ] && [ "$TAG_OBJECT" != "$NEW_COMMIT" ] && [ "$COMMIT_COUNT" -gt 2 ]; then
+    astro::die_with_hint \
+        "$NEW_REF advertises an inconsistent set of objects at $CHROMIUM_URL:" \
+        "$(printf '%s\n' "$LS_REMOTE" | sed 's/^/  /')"
+fi
+
+astro::info "  resolved: $NEW_COMMIT"
+
+# --------------------------------------------------------------------------
+# Update the lock and report the change
+# --------------------------------------------------------------------------
+
+REPORT_DIR="$(astro::report_dir)"
+REPORT="$REPORT_DIR/chromium-update-$NEW_VERSION.json"
+
+if astro::dry_run; then
+    astro::plan "update $LOCK_FILE chromium to $NEW_VERSION ($NEW_COMMIT)"
+    astro::plan "write $REPORT"
+else
+    python3 - "$LOCK_FILE" "$NEW_VERSION" "$NEW_COMMIT" "$NEW_REF" <<'PY'
+import json, sys
+
+lock_path, version, commit, ref = sys.argv[1:5]
+with open(lock_path, encoding="utf-8") as handle:
+    document = json.load(handle)
+
+document["chromium"]["version"] = version
+document["chromium"]["commit"] = commit
+document["chromium"]["ref"] = ref
+
+with open(lock_path, "w", encoding="utf-8") as handle:
+    json.dump(document, handle, indent=2)
+    handle.write("\n")
+PY
+
+    python3 "$LOCK" --validate "$LOCK_FILE" >&2
+
+    python3 - "$REPORT" "$CURRENT_VERSION" "$CURRENT_COMMIT" \
+             "$NEW_VERSION" "$NEW_COMMIT" "$CHROMIUM_URL" <<'PY'
+import json, sys
+report, old_version, old_commit, new_version, new_commit, url = sys.argv[1:7]
+with open(report, "w", encoding="utf-8") as handle:
+    json.dump({
+        "kind": "chromium-update-proposal",
+        "url": url,
+        "from": {"version": old_version, "commit": old_commit},
+        "to": {"version": new_version, "commit": new_commit},
+        "compare": f"{url.removesuffix('.git')}/+log/{old_commit}..{new_commit}",
+        "next_steps": [
+            "Review the lock diff.",
+            "Update ungoogled_chromium in the lock to the matching tag, and "
+            "verify it exists — no nearby version is substituted.",
+            "Run tools/sync-sources.sh to check out the new revision.",
+            "Run tools/apply-patches.sh; patches that no longer apply exactly "
+            "stop the run and are named in build/reports/patch-report.json.",
+        ],
+    }, handle, indent=2)
+    handle.write("\n")
+PY
+    astro::info "Report: $REPORT"
+fi
+
+printf '\n=== Proposed update ===\n'
+printf '  from  %s  %s\n' "$CURRENT_VERSION" "$CURRENT_COMMIT"
+printf '  to    %s  %s\n' "$NEW_VERSION" "$NEW_COMMIT"
+printf '=== end ===\n\n'
+
+# --------------------------------------------------------------------------
+# ungoogled-chromium must be updated deliberately, not guessed
+# --------------------------------------------------------------------------
+
+astro::warn "manual-step:ungoogled" \
+    "ungoogled_chromium is still locked to its previous commit. Its tag for a new Chromium version is published separately and is NOT derivable from the Chromium version — update it in $LOCK_FILE and verify the tag exists."
+
+if [ "$APPLY" = "1" ]; then
+    astro::info ">>> --apply: syncing sources to the new revision"
+    "$ASTRO_ROOT/tools/sync-sources.sh"
+else
+    astro::info "Proposal only. Review the lock diff, then run tools/sync-sources.sh."
+fi

--- a/tools/verify-deps.sh
+++ b/tools/verify-deps.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+# verify-deps.sh — turn a recorded `gclient revinfo` into a verdict.
+#
+# tools/sync-sources.sh writes build/reports/deps-revinfo.json after every sync.
+# Recording it proves nothing on its own: a file nobody validates is a file that
+# quietly goes wrong. This is the check (ASTRO-NEXT-002, issue #5; evidence for
+# issue #4).
+#
+# What it establishes, in order of importance:
+#
+#   1. The Chromium solution gclient actually resolved is EXACTLY the commit
+#      browser.lock.json declares. A mismatch means the tree that was synced is
+#      not the tree the repository says it builds, and it is fatal.
+#   2. What every other dependency resolved to, normalised into a stable,
+#      diffable snapshot (--record), so two syncs can be compared at all.
+#   3. Whether anything moved since a previously recorded snapshot (--baseline).
+#      The same Chromium commit with different DEPS revisions is the drift worth
+#      catching: no check that only compares the Chromium commit can see it.
+#   4. Which dependencies are pinned to something that can MOVE. This is a
+#      classification, not a hex-digit test, because most of Chromium's non-git
+#      pins are content-addressed and therefore stronger than a commit SHA, not
+#      weaker (see classify() below). Calling all 75 of them holes, as an
+#      earlier version of this file did against the real 234-entry record, is
+#      the cry-wolf failure: a report nobody believes is a report nobody reads.
+#
+# It never invents a verdict. With no revinfo file on disk it refuses and says
+# how to produce one, and it does not claim to have verified the solution
+# revision when the record does not carry one.
+#
+# Usage:
+#   tools/verify-deps.sh [options]
+
+ASTRO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export ASTRO_ROOT
+# shellcheck source=tools/lib/astro-common.sh
+source "$ASTRO_ROOT/tools/lib/astro-common.sh"
+
+LOCK_FILE="$ASTRO_ROOT/browser.lock.json"
+# ASTRO_REPORT_DIR is where tools/sync-sources.sh writes the record, so the
+# default here is derived from the same variable rather than restated: two
+# defaults that can disagree is a bug waiting for whoever exports it.
+REVINFO_FILE="$ASTRO_REPORT_DIR/deps-revinfo.json"
+BASELINE_FILE=""
+RECORD_FILE=""
+FAIL_ON_DRIFT=0
+FAIL_ON_MOVING_REF=0
+
+# The gclient solution holding Chromium. Fixed rather than configurable because
+# tools/gclient.template names it, and a mismatch between the two would mean
+# this command verified a solution nobody syncs.
+SOLUTION="src"
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: tools/verify-deps.sh [options]
+
+  --revinfo FILE     gclient revinfo --output-json record to verify
+                     (default: build/reports/deps-revinfo.json)
+  --lock FILE        Lock file (default: browser.lock.json)
+  --record FILE      Write a normalised, byte-stable snapshot of the record.
+                     Two runs over the same input produce identical output.
+  --baseline FILE    A previously recorded snapshot (or a raw revinfo JSON) to
+                     diff against. Every dependency whose revision moved is
+                     reported.
+  --fail-on-drift    Exit non-zero when the baseline diff is non-empty. CI uses
+                     this; a human reading the report does not have to.
+  --fail-on-moving-ref
+                     Exit non-zero when any dependency is pinned to a ref or tag
+                     that can be moved. Off by default: upstream Chromium ships
+                     a handful of these and Astro cannot fix them today, so
+                     failing on them by default would fail every correct build.
+  --dry-run          Print the plan; write nothing.
+  -h, --help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --revinfo)        shift; REVINFO_FILE="${1:?--revinfo needs a file}" ;;
+        --lock)           shift; LOCK_FILE="${1:?--lock needs a file}" ;;
+        --record)         shift; RECORD_FILE="${1:?--record needs a file}" ;;
+        --baseline)       shift; BASELINE_FILE="${1:?--baseline needs a file}" ;;
+        --fail-on-drift)  FAIL_ON_DRIFT=1 ;;
+        --fail-on-moving-ref) FAIL_ON_MOVING_REF=1 ;;
+        --dry-run)        ASTRO_DRY_RUN=1 ;;
+        -h|--help)        usage; exit 0 ;;
+        *)                usage; astro::die "Unknown argument: $1" ;;
+    esac
+    shift
+done
+
+astro::require_cmd python3
+
+LOCK="$ASTRO_ROOT/tools/lib/lock.py"
+astro::require_file "$LOCK" "lock reader"
+astro::require_file "$LOCK_FILE" "lock file"
+
+# --------------------------------------------------------------------------
+# Fail closed on a missing record
+#
+# The absence of a revinfo file is not "nothing to check": it means nobody has
+# observed what DEPS resolved to. Reporting success here would certify a claim
+# no evidence was ever produced for.
+# --------------------------------------------------------------------------
+
+if [ ! -f "$REVINFO_FILE" ]; then
+    astro::die_with_hint \
+        "DEPS revision record not found: $REVINFO_FILE" \
+        "" \
+        "Nothing is assumed in its absence. A verdict about DEPS revisions can" \
+        "only come from a real record of what gclient resolved." \
+        "" \
+        "Run tools/sync-sources.sh first: it writes this file with" \
+        "'gclient revinfo --output-json' once the sync completes." \
+        "" \
+        "To check a record kept elsewhere: tools/verify-deps.sh --revinfo FILE"
+fi
+
+if [ -n "$BASELINE_FILE" ]; then
+    astro::require_file "$BASELINE_FILE" "baseline snapshot"
+fi
+
+# --------------------------------------------------------------------------
+# What the lock declares
+#
+# lock.py validates against browser.lock.schema.json before returning a value,
+# so a malformed lock fails here rather than producing a comparison against a
+# field nobody checked.
+# --------------------------------------------------------------------------
+
+CHROMIUM_COMMIT="$(python3 "$LOCK" --get chromium.commit "$LOCK_FILE")"
+
+RECORD_ARG="$RECORD_FILE"
+if astro::dry_run && [ -n "$RECORD_FILE" ]; then
+    astro::plan "write normalised DEPS snapshot: $RECORD_FILE"
+    RECORD_ARG=""
+fi
+
+# --------------------------------------------------------------------------
+# The analysis itself
+#
+# python3 stdlib only: this has to run on a clean machine and on a CI runner
+# with nothing installed, exactly like tools/lib/lock.py.
+# --------------------------------------------------------------------------
+
+analysis_status=0
+python3 - \
+    "$REVINFO_FILE" "$LOCK_FILE" "$CHROMIUM_COMMIT" "$SOLUTION" \
+    "$RECORD_ARG" "$BASELINE_FILE" "$FAIL_ON_DRIFT" \
+    "$FAIL_ON_MOVING_REF" <<'PY' || analysis_status=$?
+import collections
+import json
+import os
+import re
+import sys
+
+(revinfo_path, lock_path, lock_commit, solution, record_path, baseline_path,
+ fail_on_drift, fail_on_moving_ref) = sys.argv[1:9]
+
+NO_REVISION = "<no revision recorded>"
+
+
+def die(message, *lines):
+    """Fatal, phrased for whoever has to fix it.
+
+    SystemExit is not reported as a traceback, which matters here: a stack
+    trace tells the reader where this file broke, not what is wrong with their
+    checkout.
+    """
+    print(f"ERROR {message}", file=sys.stderr)
+    for line in lines:
+        print(f"      {line}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_json(path, what):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError as error:
+        die(
+            f"{what} is not valid JSON: {path}",
+            str(error),
+            "'gclient revinfo --output-json' writes this file. A truncated or "
+            "hand-edited record is not evidence of anything.",
+        )
+
+
+def normalise_entry(dependency, value, source):
+    """One revinfo entry as (url, revision).
+
+    gclient writes 'url@revision' strings. Some versions, and some
+    post-processed records, carry a nested object instead. Both are accepted;
+    anything else is refused rather than guessed at, because a guess here
+    silently produces a revision nobody resolved.
+    """
+    if isinstance(value, str):
+        # Split on the LAST '@': a revision may be a ref such as
+        # refs/heads/main, which contains no '@' but does contain '/'.
+        url, separator, revision = value.rpartition("@")
+        if not separator:
+            return value, ""
+        return url, revision
+
+    if isinstance(value, dict):
+        url = value.get("url")
+        revision = value.get("rev")
+        if revision is None:
+            revision = value.get("revision")
+        if isinstance(url, str) and isinstance(revision, str):
+            return url, revision
+        if isinstance(url, str) and revision is None:
+            # A nested entry whose url still carries the revision.
+            return normalise_entry(dependency, url, source)
+        die(
+            f"unrecognised revinfo entry for '{dependency}' in {source}: an "
+            f"object with keys {sorted(value)}.",
+            "A nested entry must carry a string 'url' and a string 'rev' (or "
+            "'revision').",
+            "Refusing to guess which field holds the revision.",
+        )
+
+    die(
+        f"unrecognised revinfo entry for '{dependency}' in {source}: expected a "
+        f"'url@revision' string or an object, got {type(value).__name__}.",
+        "Refusing to guess at a shape this tool does not recognise: a guessed "
+        "revision is worse than no revision, because it reads as verified.",
+    )
+
+
+def normalise(document, source):
+    if not isinstance(document, dict):
+        die(
+            f"unrecognised revinfo shape in {source}: the top level is a "
+            f"{type(document).__name__}, not an object.",
+            "'gclient revinfo --output-json' writes an object mapping every "
+            "dependency path to its resolved 'url@revision'.",
+            "Refusing to guess at a shape this tool does not recognise.",
+        )
+    return {
+        dependency: normalise_entry(dependency, value, source)
+        for dependency, value in document.items()
+    }
+
+
+def render(entries):
+    """The normalised snapshot: sorted 'path<TAB>url@revision' lines.
+
+    Deterministic by construction — sorted keys, no timestamp, no host or path
+    of the machine that produced it — so two runs over the same input are
+    byte-identical and a diff between two snapshots is signal only.
+    """
+    return "".join(
+        f"{dependency}\t{entries[dependency][0]}@{entries[dependency][1]}\n"
+        for dependency in sorted(entries)
+    )
+
+
+def read_snapshot(path):
+    """A --record snapshot, or a raw revinfo JSON, as normalised entries.
+
+    Both are accepted because both are things a previous run legitimately left
+    behind. The two are told apart by their first character rather than by a
+    filename convention, and an unrecognised line is refused.
+    """
+    with open(path, encoding="utf-8") as handle:
+        text = handle.read()
+
+    if text.lstrip()[:1] in ("{", "["):
+        return normalise(read_json(path, "baseline"), path)
+
+    entries = {}
+    for number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        dependency, tab, value = line.partition("\t")
+        if not tab:
+            die(
+                f"unrecognised baseline line {number} in {path}: {line!r}",
+                "A recorded snapshot is TAB-separated 'path<TAB>url@revision' "
+                "lines, as written by --record.",
+                "Pass a --record snapshot or a raw gclient revinfo JSON.",
+            )
+        entries[dependency] = normalise_entry(dependency, value, path)
+    return entries
+
+
+# --- How a dependency is pinned ---------------------------------------------
+#
+# These patterns are derived from a real 234-entry record of a fully synced
+# Chromium checkout, not from what a pin "looks like". Counting anything that is
+# not a 40-character hex string as unpinned called 75 of those 234 holes in the
+# lock, when the true number is 10.
+
+COMMIT_PINNED = "commit-pinned"
+CONTENT_ADDRESSED = "content-addressed"
+MOVING_REF = "moving-ref"
+UNCLASSIFIED = "unclassified"
+
+SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+# A CIPD package pinned by `git_revision:<sha>` IS commit-pinned; the prefix is
+# CIPD tag syntax, not a weaker pin. Six of the real record's entries — gn,
+# siso, three luci-go tools and resultdb — are this shape.
+GIT_REVISION = re.compile(r"^git_revision:[0-9a-f]{40}$")
+
+# A CIPD instance id: base64url of the package content's hash plus a trailing
+# byte naming the hash algorithm, which is why it ends in 'C'. This is a
+# content address — strictly stronger than a git SHA, since it names the built
+# artifact rather than the source it was built from. All ten in the real record
+# are exactly 44 characters.
+CIPD_INSTANCE = re.compile(r"^[A-Za-z0-9_-]{43}C$")
+
+# A full git (40) or SHA-256 (64) digest inside a GCS object name. Bounded on
+# both sides so an abbreviated hash embedded in a longer token — the `g5bd8dadb`
+# in a clang tarball name — does not read as a content address.
+EMBEDDED_DIGEST = re.compile(
+    r"(?<![0-9a-fA-F])(?:[0-9a-f]{40}|[0-9a-f]{64})(?![0-9a-fA-F])"
+)
+
+
+def classify(url, revision):
+    """How strongly this dependency is pinned.
+
+    One question decides it: can this resolve to different bytes on a later
+    sync, with nothing in this repository changing?
+
+      commit-pinned      no — a commit SHA, however it is spelled
+      content-addressed  no — the name IS the content's hash, so a different
+                         object is a different name
+      moving-ref         YES — a CIPD ref or tag (version:2, latest) or a git
+                         ref (refs/heads/main, refs/tags/x), resolved at sync
+                         time. Only this is a finding.
+      unclassified       unknown — this record does not say. Not folded into
+                         either answer: guessing in either direction is how a
+                         check stops being believed.
+    """
+    if not revision:
+        # A GCS object is pinned by its name, and Chromium names most of them
+        # after the object's own digest.
+        if url.startswith("gs://") and EMBEDDED_DIGEST.search(url):
+            return CONTENT_ADDRESSED
+        return UNCLASSIFIED
+    if SHA40.match(revision) or GIT_REVISION.match(revision):
+        return COMMIT_PINNED
+    if CIPD_INSTANCE.match(revision):
+        return CONTENT_ADDRESSED
+    return MOVING_REF
+
+
+current = normalise(read_json(revinfo_path, "revinfo record"), revinfo_path)
+
+# --- Evidence is written before any verdict, so a failing run still leaves a
+# --- comparable record of what it saw.
+
+if record_path:
+    directory = os.path.dirname(record_path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(record_path, "w", encoding="utf-8") as handle:
+        handle.write(render(current))
+
+# --- Summary ----------------------------------------------------------------
+
+# The solution is excluded from the pin classification and reported on its own:
+# it is not pinned by DEPS at all, and counting it as unpinned would put a
+# permanent false finding in every report.
+kinds = {
+    dependency: classify(url, revision)
+    for dependency, (url, revision) in current.items()
+    if dependency != solution
+}
+counts = collections.Counter(kinds.values())
+
+moving = sorted(d for d, kind in kinds.items() if kind == MOVING_REF)
+unclassified = sorted(d for d, kind in kinds.items() if kind == UNCLASSIFIED)
+
+print("=== DEPS verification ===")
+print(f"  revinfo:                 {revinfo_path}")
+print(f"  lock:                    {lock_path}")
+print(f"  solution:                {solution}")
+print(f"  dependencies:            {len(current)}")
+print(f"  solution entry:          {1 if solution in current else 0}")
+print(f"  commit-pinned:           {counts[COMMIT_PINNED]}")
+print(f"  content-addressed:       {counts[CONTENT_ADDRESSED]}")
+print(f"  moving-ref:              {counts[MOVING_REF]}")
+print(f"  unclassified:            {counts[UNCLASSIFIED]}")
+if record_path:
+    print(f"  snapshot recorded:       {record_path}")
+
+if moving:
+    print(f"--- pinned to a moving ref ({len(moving)}) ---")
+    for dependency in moving:
+        _url, revision = current[dependency]
+        print(f"  MOVING-REF  {dependency}  {revision}")
+    print("  A ref or tag is resolved at sync time, so the same Chromium commit can")
+    print("  resolve these to different bytes on a later sync with nothing in this")
+    print("  repository changing. This is the hole in the lock's guarantee.")
+    print("  A commit SHA, a CIPD instance id and a digest-named GCS object cannot")
+    print("  move, and are deliberately not listed here.")
+
+if unclassified:
+    print(f"--- not classifiable from this record ({len(unclassified)}) ---")
+    for dependency in unclassified:
+        url, revision = current[dependency]
+        print(f"  UNKNOWN-PIN  {dependency}  {revision or NO_REVISION}  {url}")
+    print("  These carry no revision in this record and no digest in their name, so")
+    print("  the record does not say how they are pinned. A checksum a DEPS entry")
+    print("  may declare for such an object is not written into revinfo, so it")
+    print("  cannot be read here. Reported rather than assumed either way, and NOT")
+    print("  counted as a moving ref.")
+
+# --- Drift against a previously recorded snapshot ---------------------------
+
+drift = 0
+if baseline_path:
+    baseline = read_snapshot(baseline_path)
+
+    changed = [
+        (dependency, baseline[dependency], current[dependency])
+        for dependency in sorted(set(baseline) & set(current))
+        if baseline[dependency] != current[dependency]
+    ]
+    added = sorted(set(current) - set(baseline))
+    removed = sorted(set(baseline) - set(current))
+    drift = len(changed) + len(added) + len(removed)
+
+    print(f"--- baseline: {baseline_path} ---")
+    if drift:
+        print(
+            f"--- DEPS drift ({len(changed)} changed, {len(added)} added, "
+            f"{len(removed)} removed) ---"
+        )
+        for dependency, (was_url, was_revision), (now_url, now_revision) in changed:
+            print(f"  CHANGED  {dependency}")
+            print(f"             baseline  {was_url}@{was_revision}")
+            print(f"             current   {now_url}@{now_revision}")
+        for dependency in added:
+            url, revision = current[dependency]
+            print(f"  ADDED    {dependency}")
+            print(f"             current   {url}@{revision}")
+        for dependency in removed:
+            url, revision = baseline[dependency]
+            print(f"  REMOVED  {dependency}")
+            print(f"             baseline  {url}@{revision}")
+
+        was_solution = baseline.get(solution)
+        now_solution = current.get(solution)
+        if was_solution and now_solution and was_solution[1] == now_solution[1]:
+            print("  NOTE  Both snapshots record the same Chromium commit")
+            print(f"        ({now_solution[1]}), yet the dependency revisions above")
+            print("        differ. Two syncs of one Chromium commit therefore produced")
+            print("        different sources. This is precisely the drift a recorded")
+            print("        revinfo exists to catch, and it is invisible to any check")
+            print("        that compares only the Chromium commit.")
+    else:
+        print(
+            f"  no dependency revisions differ "
+            f"({len(current)} dependencies compared)"
+        )
+
+# --- The verdict ------------------------------------------------------------
+
+if solution not in current:
+    listed = sorted(current)
+    die(
+        f"the '{solution}' solution is absent from {revinfo_path}.",
+        f"That record holds {len(current)} entries; the first few are: "
+        f"{', '.join(listed[:5]) or '(none)'}",
+        "Without it there is nothing to compare the locked Chromium commit "
+        "against, and this command will not report a verdict it did not reach.",
+        "Check that the record came from a sync of tools/gclient.template, "
+        f"whose solution is named '{solution}'.",
+    )
+
+resolved_url, resolved = current[solution]
+
+if not resolved:
+    # tools/gclient.template sets managed: False precisely so gclient does not
+    # select the solution's revision, so a null rev here is the designed state
+    # and not a fault. Saying so is not the same as verifying it: the check that
+    # does verify it lives in tools/sync-sources.sh, and this says where.
+    print(f"  DEFERRED  '{solution}' carries no revision in this record.")
+    print("            tools/gclient.template sets managed: False, so gclient does not")
+    print("            select the solution's revision — tools/sync-sources.sh does, and")
+    print("            it compares `git rev-parse HEAD` against the lock after the sync.")
+    print(f"            Locked commit:  {lock_commit}")
+    print("            Re-check the checkout itself with:")
+    print("              tools/sync-sources.sh --verify-only")
+    print("            This record does not establish the solution revision, and this")
+    print("            command does not claim it does.")
+    print(
+        f"  CONCLUSION  {len(kinds)} dependencies classified against "
+        f"{lock_path}; the solution revision is NOT established here."
+    )
+elif resolved != lock_commit:
+    die(
+        "the Chromium solution does not match the lock.",
+        f"  solution:           {solution}  ({resolved_url})",
+        f"  browser.lock.json:  {lock_commit}",
+        f"  gclient revinfo:    {resolved}",
+        "",
+        "The tree that was synced is not the tree this repository declares it "
+        "builds. Anything produced from it is unattributable.",
+        "Run tools/sync-sources.sh to bring the checkout to the locked commit, "
+        "or change the lock deliberately if the new revision is intended.",
+    )
+else:
+    print(
+        f"  VERIFIED  {solution} resolves to {resolved}, the commit "
+        f"browser.lock.json records"
+    )
+    print(
+        f"  CONCLUSION  {len(kinds)} dependencies classified; the solution "
+        f"matches {lock_path}."
+    )
+
+if drift and fail_on_drift == "1":
+    die(
+        f"--fail-on-drift: {drift} dependency difference(s) against "
+        f"{baseline_path}.",
+        "The differences are listed above. They are not automatically wrong — "
+        "they are a change to the build's inputs that nobody has approved yet.",
+        "Re-record the baseline once the change is deliberate.",
+    )
+
+if moving and fail_on_moving_ref == "1":
+    die(
+        f"--fail-on-moving-ref: {len(moving)} dependency(ies) pinned to a ref "
+        "or tag that can be moved.",
+        "They are listed above. Each can resolve to different bytes on a later "
+        "sync with nothing in this repository changing.",
+        "Content-addressed and commit-pinned dependencies are not counted here: "
+        "this failure names only what can actually move.",
+    )
+PY
+
+if [ "$analysis_status" -ne 0 ]; then
+    astro::die_with_hint \
+        "DEPS verification failed (exit $analysis_status)." \
+        "The reason is printed above. Nothing here may be treated as verified:" \
+        "the recorded DEPS revisions do not support the claim that this checkout" \
+        "corresponds to browser.lock.json."
+fi
+
+# Deliberately not "verified": what this record establishes is printed above as
+# a CONCLUSION line, and it differs depending on whether the record carries a
+# solution revision at all. A blanket "verified" here would overwrite that
+# distinction with the reassuring reading.
+astro::info "DEPS record checked: $REVINFO_FILE"


### PR DESCRIPTION
Refs #5. **Does not close it** — acceptance criteria remain unverified, and an auto-closing keyword would retire the issue on merge before its evidence exists. Parent epic #3. **Stacked on #31 (#4)** — base is `feature/astro-next-4-safe-fail-closed-build`, and GitHub will retarget to `master` when #31 merges. It uses `tools/lib/astro-common.sh` and `astro::resolve_chromium_src` from that PR.

## Summary

Every local, CI and release build now starts from an explicitly declared set of source revisions. A cached runner cannot decide which Chromium gets compiled.

- `browser.lock.json` + a validated schema pin Chromium, depot_tools and the ungoogled patch set by full commit SHA
- `tools/sync-sources.sh` is the single sync command — documentation and CI run the same implementation
- `tools/generate-provenance.sh` records what each build was *actually* made from, and every release artifact ships it
- 4 new test cases (18 total, 279 assertions), still dependency-free and fixture-driven
- ShellCheck clean at `--severity=style`; the pattern scanner now reads workflow files too

## Architectural changes

### `browser.lock.json` + `browser.lock.schema.json`

Full 40-character SHAs with the origin each came from and, where one exists, the ref it was resolved *from*. `commit` is authoritative, so a moved or retagged ref cannot change a build.

**depot_tools is pinned, and pinned first**, because it resolves every other revision — `gclient`, `gn` and `autoninja` all come from it, so the previous `cd depot_tools && git pull` silently changed what every other pin meant.

`tools/lib/lock.py` validates by **reading** the schema rather than re-stating its rules, so the two cannot drift. It implements the JSON Schema subset the lock uses; a keyword it cannot enforce is a **hard error, not a skip**, because silently ignoring a constraint makes a schema look enforced when it is not.

Rejections name the reason, since every dangerous input still *looks* like a revision:

```
$ python3 tools/lib/lock.py --validate bad.json
ERROR lock file does not satisfy browser.lock.schema.json:
    - chromium.commit: 'ae03f7f' does not match ^[0-9a-f]{40}$
      An abbreviated SHA is not acceptable: abbreviations are not stable as a
      repository grows, and two objects can share a prefix. Record the full 40
      characters.
```

### `tools/sync-sources.sh` + `tools/gclient.template`

The one synchronisation command. Guarantees:

- depot_tools pinned **before** anything invokes `gclient`/`gn`/`autoninja`
- fetching never changes the selected commit; the checkout moves only in an explicit `checkout --detach`
- the checkout ends **detached** at the locked commit — a branch at the right commit can be advanced afterwards, and a fresh `git clone` lands on one, so this is corrected even when the SHA already matches
- `.gclient` rendered from committed configuration, not string-built per run
- `gclient sync --revision src@<locked-sha>`, with HEAD re-verified afterwards
- DEPS-resolved revisions recorded to `build/reports/deps-revinfo.json`
- a second invocation does no work beyond verification

`--verify-only` never writes and fails on: wrong commit, attached HEAD, uncommitted changes, leftover `.rej`/`.orig`, linked worktrees, `.gclient` ≠ template. **`ASTRO_ALLOW_DIRTY_CHROMIUM` has no effect in that mode** — a gate an environment variable can wave through is not a gate — and CI asserts it is never set.

### `tools/generate-provenance.sh`

Read from the trees **on disk**, never from the lock. Provenance derived from the lock could only restate the lock, and would certify a stale runner's build as correct.

`drift` and `dirty_worktrees` are the fields a suspicious reader wants; `reproducible` is true only when both are empty. `--require-match` turns either into a non-zero exit — a release artifact must record revisions somebody can check out again.

No wall-clock timestamp is a build input (`timestamp_policy: "excluded-from-build-inputs"`): embedding one makes two builds of identical sources differ, defeating the property the file exists to record.

### `tools/update-chromium.sh`

Resolves a version to exactly one commit at the origin, checks the tag/commit relationship, updates the lock and writes a change report. Proposal-only by default — an update changes what the whole project compiles, so it lands as a reviewable lock diff.

`tools/sync-ungoogled.sh` loses its fallback chain entirely (see Findings).

`tools/fetch-chromium.sh` becomes a deprecated wrapper that delegates, so a stale runbook cannot reintroduce the old behaviour; a `CHROMIUM_VERSION` disagreeing with the lock is an error naming `update-chromium.sh`.

### CI

The five per-platform copies of the cache-skip are replaced by an unconditional `tools/sync-sources.sh` plus a separate `--verify-only` step — separate on purpose, so a sync that silently did nothing still cannot produce a build. The `CHROMIUM_VERSION` env var is gone, the five unguarded destructive resets are gone, and a `concurrency` group stops two jobs mutating one runner's shared checkout.

## Chromium-owned files modified

**None.** Every change is to Astro-owned tooling, CI, the lock/schema and documentation. Nothing under `chromium/src/` is modified; this issue changes only *which commit* is checked out and how that is verified, never the contents of the checkout.

## Findings

### 1. CI compiled whatever commit the runner happened to hold

`release.yml` did this in all five platform jobs:

```yaml
if [ ! -d "chromium/src/.git" ]; then
  tools/fetch-chromium.sh
else
  echo "Chromium source cached, skipping fetch"
fi
```

A self-hosted runner that had ever fetched Chromium never synchronised again — forever, unvalidated. Nothing compared the checkout against any declaration, because none existed. Alongside it, five copies of `git checkout -- . 2>/dev/null || true` + `git clean -fd 2>/dev/null || true`, unguarded and with both failures suppressed.

### 2. The version lookup fell back to a *different browser*

`sync-ungoogled.sh` tried the exact tag, then `git tag -l "$MAJOR.*" | sort -V | tail -1`, then `master` — printing `WARNING: Patches may not apply cleanly` and **exiting zero**. A version bump could therefore build against a patch set written for a different Chromium major, with one line of console output as the only trace.

That is the epic's "no exact-version lookup falls back to a merely similar version" rule. Verified against the real remote after the fix:

```
$ tools/update-chromium.sh 999.0.9999.99
ERROR Chromium 999.0.9999.99 does not exist at https://chromium.googlesource.com/chromium/src.git
      No nearby version is substituted. …
$ echo $?   # 1, and browser.lock.json untouched
```

### 3. An annotated tag makes a naive `ls-remote` comparison report permanent false drift

`git ls-remote` reports `refs/tags/X` as the tag **object** and only `refs/tags/X^{}` as the commit; a lightweight tag has no `^{}` line at all. My first `--check-remote` compared the unpeeled value and reported ungoogled-chromium's `146.0.7680.177-1` as drifted — tag object `87bc3cfe` versus commit `ecd0ec03` — when the lock was correct.

Worth recording because it is the "check that cries wolf" trap: shipped as-is it would have reported drift on every annotated tag forever, and whoever hit it would have disabled the check. Chromium's own tags are lightweight, so a test using only those would never have caught it — the fixture deliberately uses an annotated tag.

### 4. Two false negatives in the pattern scanner from #4

Both found while writing this PR, both in the dangerous direction:

- `|| true` followed by `)` was not matched, so it hid inside command substitutions — the easiest place to hide one.
- Quotes inside `$(...)` inside a quoted string confused the tokenizer: the inner `"` appeared to close the outer one, and the code between vanished from the scan. This was actively concealing a real `|| true` I had written in `sync-sources.sh`. Now tracked with a proper state stack, and the exact shape is a test case.

### 5. ShellCheck itself crashes intermittently

Observed twice as SIGABRT (134) and SIGSEGV (139) in roughly forty invocations, only under concurrent load, never reproducible in isolation (0 failures in 15 consecutive runs of the case, 0 in 24 direct invocations).

Not papered over. A crashed linter is not a lint finding, and a gate that cannot tell them apart either reports phantom errors or gets marked flaky and disabled — so a signal-level exit is retried once and, if it recurs, reported as a tool crash in its own words. A real lint failure is never retried.

## Tests

```
=== 18 passed, 0 failed ===   (279 assertions)
```

Four new cases:

| Case | Asserts |
|---|---|
| `lock-schema-validation` | the repo's own lock is valid and https-only; abbreviated / uppercase / branch / tag SHAs, unknown fields, unknown `lockfile_version`, malformed JSON and a reason-less unpinned entry are each rejected **with the reason named**; and a schema keyword the validator cannot enforce is a hard error |
| `sync-enforces-locked-revisions` | bootstrap; detached HEAD; two syncs produce byte-identical output; `--verify-only` rejects a wrong commit **without modifying anything**, default mode corrects it; a remote branch advancing does not move the build |
| `sync-rejects-stale-and-dirty-checkouts` | uncommitted work, `.rej` artifacts and a leftover `astro-<version>` branch each refused and named; the dirty override works in default mode and is **ignored** under `--verify-only`; `--dry-run` changes nothing |
| `provenance-records-what-is-on-disk` | recorded revisions match the real fixtures rather than the lock; the Astro commit is resolved, not locked; GN args recorded literally and by hash; drift and dirty trees reported; `--require-match` refuses both |

Design points carried over from #4: every failure case asserts **why** it failed; cases must print a pass token and record at least one assertion; the scanner is mutation-tested against each rule, including the two new ones, and separately asserted *not* to fire on a bootstrapping script that legitimately tests for a missing checkout.

### Verification commands run

```bash
tools/tests/run.sh                                     # 18 passed, 0 failed
python3 tools/lib/lock.py --validate                   # valid; lists 4 revisions
python3 tools/lib/lock.py --check-remote               # every locked ref still resolves
python3 tools/tests/lib/scan-shell-patterns.py \
    tools/*.sh tools/lib/*.sh .github/workflows/*.yml  # scanned 24, no banned patterns
shellcheck -x --source-path=SCRIPTDIR --severity=style \
    tools/*.sh tools/lib/*.sh tools/tests/**/*.sh      # exit 0
tools/update-chromium.sh 999.0.9999.99                 # exit 1, lock untouched
! grep -rn 'skipping fetch' .github/workflows/
! grep -qE '^[^#]*git .*\bpull\b' tools/*.sh tools/lib/*.sh
```

`--check-remote` is against the real upstream remotes and confirms the locked Chromium SHA `ae03f7fb…` really is what `refs/tags/146.0.7680.177` resolves to. One run hit a transient TLS error and **failed loudly** rather than passing — the intended behaviour — and succeeded on retry.

### Not verified, stated plainly

**The end-to-end bootstrap acceptance criterion is not proven and its box is left unchecked.** "Deleting all local source checkouts and running the documented bootstrap command reconstructs the expected source state" needs a ~55 GB fetch and there is no Chromium checkout on this machine — which is itself #4's Finding 1.

What *was* exercised: the entire sync algorithm against synthetic git fixtures reproducing each real shape (wrong commit, moving branch, leftover branch, dirty tree, `.rej` artifacts, attached HEAD, bootstrap-from-empty), the locked SHAs verified to resolve at the real upstream remotes, and the real depot_tools and ungoogled clones already on disk read for their revisions.

Likewise unproven: `gclient sync --revision src@<sha>` against a real Chromium DEPS graph, and `gclient revinfo` output. Those need the checkout too.

## Security impact

Positive; no new attack surface. No credential path, endpoint, WebUI or CSP is touched.

- **Removes an unpinned supply chain.** Chromium, depot_tools and the ungoogled patch set were all selected at run time — by an env var default, an unconstrained `git pull`, and a tag search that would settle for `master`. Each was a path by which a build could compile something nobody reviewed. All three are now commit-pinned and verified.
- **A stale runner can no longer ship a binary.** `--verify-only` runs before every build in CI and inside `tools/build.sh`.
- **Security updates become auditable.** The lock diff is the complete statement of what changed about the sources, and `docs/reproducibility.mdx` documents how one is selected and promoted.
- **Release artifacts carry provenance**, so a shipped binary states the revisions, GN args and compiler it came from — and says so when it drifted.
- **The one remaining unpinned input is declared**, not hidden: `third_party.adblock_rust`, with a schema-enforced reason.

## Migration and compatibility impact

No data migration; nothing touches profiles or user data.

**For an existing local checkout:**

```bash
git -C chromium/src status   # review anything you want to keep
tools/sync-sources.sh        # detaches at the locked commit
tools/sync-sources.sh --verify-only
```

It refuses rather than discarding if the checkout carries local changes — deliberate; keep or discard them, then re-run.

**Behaviour changes that will surprise someone:**

1. `CHROMIUM_VERSION=... tools/fetch-chromium.sh` now **errors** if it disagrees with the lock, naming `update-chromium.sh`. An env var no longer selects what gets compiled.
2. `tools/sync-ungoogled.sh` fails instead of guessing a tag.
3. `tools/build.sh` refuses a checkout off the locked revision. `ASTRO_SKIP_LOCK_VERIFY=1` exists for bisecting upstream, warns, and shows up in provenance as drift.
4. Self-hosted runners will do real work on their next run: the sync detaches the checkout at the locked commit. Anything uncommitted on those runners is refused rather than discarded, so it must be dealt with once, by hand.

### Developer working-tree preservation

52 paths of pre-existing uncommitted developer work remain untouched. This PR commits no file that was not part of #5's scope. `tools/setup-win-sdk.sh` (untracked WIP) is still deliberately not committed.

## Remaining work

- **#6** — behavioural baseline, the next issue in the epic's Phase 0 order.
- **#4's three unchecked boxes** (`gn gen` / `gn check` / compile, and the modified-tree summary in CI logs) unblock once a real checkout exists — which is now one `tools/sync-sources.sh` away.
- **Pinning `adblock_rust`** means changing how vendoring works, which affects browser output; declared unpinned with a reason rather than folded in here.
- **#27** owns the full path-aware CI; `build-safety.yml` gained a lock-validation step but is still a first gate.

Deliberately out of scope, per the issue: the `//astro` downstream architecture and removing the patch system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)